### PR TITLE
fix: トップページのgetStaticPropsでのシリアライズエラー修正

### DIFF
--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -38,10 +38,16 @@ export function getSortedPostsData(): Result<Omit<PostData, 'contentHtml'>[], Po
         // gray-matter を使用してメタデータを解析
         const matterResult = matter(fileContents);
 
+        // 日付が Date オブジェクトの場合、YYYY-MM-DD 形式の文字列に変換
+        const dateString =
+          matterResult.data.date instanceof Date
+            ? matterResult.data.date.toISOString().split('T')[0]
+            : matterResult.data.date;
+
         return ok({
           id,
           title: matterResult.data.title,
-          date: matterResult.data.date,
+          date: dateString, // 文字列に変換した日付を使用
           tags: matterResult.data.tags || [],
         });
       } catch (e) {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -36,10 +36,20 @@ export default function Home({ posts }: Props) {
 }
 
 export const getStaticProps: GetStaticProps<Props> = async () => {
-  const posts = getSortedPostsData();
+  const postsResult = getSortedPostsData();
+
+  if (postsResult.isOk()) {
+    // 成功した場合のみ Result から値を取り出して props に渡す
+    return {
+      props: {
+        posts: postsResult.value,
+      },
+    };
+  }
+
+  // isOk() でなければエラーなので、ここでエラー処理
+  console.error('Error fetching posts:', postsResult.error);
   return {
-    props: {
-      posts,
-    },
+    notFound: true,
   };
 };


### PR DESCRIPTION
## 概要
Issue #1 の対応。
開発サーバー起動時にトップページで発生していたデータシリアライズエラーを修正しました。

## 変更内容
- `src/lib/posts.ts` (`getSortedPostsData`):
  - `matterResult.data.date` が Date オブジェクトの場合、`YYYY-MM-DD` 形式の文字列に変換するように修正。
- `src/pages/index.tsx` (`getStaticProps`):
  - `getSortedPostsData` から返される `Result` 型をチェックし、成功した場合 (`isOk`) のみ中の `value` を `props.posts` に渡すように修正。
  - エラーの場合 (`isErr`) は `notFound: true` を返すように修正。

## テスト手順
1. `npm run dev` で開発サーバーを起動
2. ブラウザで `http://localhost:3000` (または利用可能なポート) にアクセスし、エラーなくトップページが表示されることを確認

Closes #1