### PR TITLE
fix(storybook): Use object format for staticDirs to fix CI build error (Issue #20)

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -12,6 +12,6 @@ const config: StorybookConfig = {
     name: '@storybook/nextjs',
     options: {},
   },
-  staticDirs: ['../public'],
+  staticDirs: [{ from: '../public', to: '/' }],
 };
 export default config;


### PR DESCRIPTION
## 概要
Issue #20 の対応として、GitHub Actions の CI で発生していた Storybook のビルドエラー (`Failed to load static files, no such directory: ../public`) を修正しました。

## 変更内容
- 更新: `.storybook/main.ts`
  - `staticDirs` の設定を文字列配列 (`['../public']`) からオブジェクト形式 (`[{ from: '../public', to: '/' }]`) に変更しました。これにより、CI 環境でのパス解決が改善されることを期待します。

## テスト手順
- このプルリクエスト自体によってトリガーされる GitHub Actions のワークフロー実行結果を確認します。
- `build-and-deploy` ジョブ内の `Build Storybook` ステップが正常に完了することを確認します。

## レビューのポイント
- `staticDirs` の変更によってローカルの Storybook ビルド (`npm run build-storybook`) に影響がないか。
- CI が正常に完了するか。

## 関連 Issue
- Refs #20