### PR TITLE
fix(storybook): Use NormalModuleReplacementPlugin to fix CI build error (Issue #20 - Retry)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ lerna-debug.log*
 # Optional Files
 *.log 
 *storybook.log
+
+# Storybook build output
+storybook-static

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -12,6 +12,6 @@ const config: StorybookConfig = {
     name: '@storybook/nextjs',
     options: {},
   },
-  staticDirs: [{ from: '../public', to: '/' }],
+  staticDirs: [{ from: './public', to: '/' }],
 };
 export default config;

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -12,6 +12,6 @@ const config: StorybookConfig = {
     name: '@storybook/nextjs',
     options: {},
   },
-  staticDirs: [{ from: './public', to: '/' }],
+  staticDirs: [{ from: '../public', to: '/' }],
 };
 export default config;

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,4 +1,7 @@
 import type { StorybookConfig } from '@storybook/nextjs';
+import type { Configuration } from 'webpack';
+import path from 'path'; // Import path for resolving alias
+import webpack from 'webpack'; // Import webpack
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
@@ -13,5 +16,25 @@ const config: StorybookConfig = {
     options: {},
   },
   staticDirs: [{ from: '../public', to: '/' }],
+
+  webpackFinal: async (config: Configuration) => {
+    config.plugins = config.plugins || [];
+    config.plugins.push(
+      new webpack.NormalModuleReplacementPlugin(/^node:/, (resource: { request: string }) => {
+        // Remove the 'node:' prefix
+        resource.request = resource.request.replace(/^node:/, '');
+      })
+    );
+
+    // Keep the fallback just in case, but the plugin should handle the primary issue
+    config.resolve = config.resolve || {};
+    config.resolve.fallback = {
+      ...config.resolve.fallback,
+      fs: false,
+      path: false,
+    };
+
+    return config;
+  },
 };
 export default config;

--- a/src/lib/empty-shim.js
+++ b/src/lib/empty-shim.js
@@ -1,2 +1,0 @@
-// This file is intentionally left empty.
-// It is used as a shim for Node.js built-in modules in Storybook's Webpack config.

--- a/src/lib/empty-shim.js
+++ b/src/lib/empty-shim.js
@@ -1,0 +1,2 @@
+// This file is intentionally left empty.
+// It is used as a shim for Node.js built-in modules in Storybook's Webpack config.


### PR DESCRIPTION
## 概要
Issue #20 の対応、再提出です。
CI で発生していた Storybook のビルドエラー (`UnhandledSchemeError: Reading from "node:fs"`) を修正するため、`.storybook/main.ts` に `NormalModuleReplacementPlugin` を追加します。

前回の PR #22 は、この修正が含まれる *前* の状態でマージされてしまっていたため、改めて正しい修正を含むこの PR を提出します。

## 変更内容
- 更新: `.storybook/main.ts`
  - `webpackFinal` に `NormalModuleReplacementPlugin` を追加し、`node:` プレフィックス付きモジュールリクエストを通常のモジュール名に変換するようにしました。
  - (前回のコミットで追加した `fs`, `path` のフォールバック設定も残しています)
- 追加: `src/lib/empty-shim.js` (エイリアス設定時に作成したが、現在は未使用のはず)
- 更新: `.gitignore` (`storybook-static` を追加)

## テスト手順
- このプルリクエストによってトリガーされる GitHub Actions のワークフロー実行結果を確認します。
- `build-and-deploy` ジョブ内の `Build Storybook` および後続の全てのステップが正常に完了することを確認します。

## レビューのポイント
- `webpackFinal` の設定は正しいか。
- CI が正常に完了するか。

## 関連 Issue
- Refs #20