### PR TITLE
ci: Clear .next cache before building Next.js app

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
       # main ブランチへのプッシュ時のみデプロイを実行
       - name: Build Next.js App
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: npm run build # out/ ディレクトリが生成される
+        run: rm -rf .next && npm run build # Clear cache before building
 
       - name: Deploy to gh-pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
## 概要
`next build` 時に `pageExtensions` の設定が効かず、`.stories.tsx` ファイルがページとして認識されてしまう問題を修正するため、ビルド前に Next.js のキャッシュ (`.next` ディレクトリ) を削除するステップを CI に追加します。

## 変更内容
- 更新: `.github/workflows/deploy.yml`
  - `Build Next.js App` ステップの `run` コマンドの先頭に `rm -rf .next &&` を追加しました。

## テスト手順
- このプルリクエストをマージ後、`main` ブランチへのプッシュによってトリガーされる GitHub Actions のワークフロー実行結果を確認します。
- `build-and-deploy` ジョブ内の `Build Next.js App` ステップが正常に完了することを確認します。

## 関連 Issue
- (もしあれば Issue 番号を記載)