### PR TITLE
refactor: Move story files to src/stories and fix imports

### DIFF
--- a/src/stories/ArticleCard.stories.tsx
+++ b/src/stories/ArticleCard.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { within, expect } from '@storybook/test';
-import ArticleCard from './ArticleCard';
+import ArticleCard from '../components/ArticleCard';
+import { PostData } from '../lib/posts';
 
 // モックデータ (Home.test.tsx などから拝借)
 const mockArticleData = {

--- a/src/stories/Layout.stories.tsx
+++ b/src/stories/Layout.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { within, expect } from '@storybook/test';
-import Layout from './Layout';
+import Layout from '../components/Layout';
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 const meta: Meta<typeof Layout> = {

--- a/src/stories/index.stories.tsx
+++ b/src/stories/index.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { within, expect } from '@storybook/test';
-import Home from './index'; // Import the Home component
+import HomePage from '../pages/index'; // <-- Update path here
+import { PostData } from '../lib/posts'; // Assuming PostData type is still in lib/posts
 
 // モックデータ (Home.test.tsx からコピー)
 const mockPosts = [
@@ -18,9 +19,9 @@ const mockPosts = [
   },
 ];
 
-const meta: Meta<typeof Home> = {
+const meta: Meta<typeof HomePage> = {
   title: 'Pages/Home', // Storybookでの表示名
-  component: Home,
+  component: HomePage,
   parameters: {
     layout: 'fullscreen', // レイアウトに合わせて全画面表示
   },
@@ -31,7 +32,7 @@ const meta: Meta<typeof Home> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof Home>;
+type Story = StoryObj<typeof HomePage>;
 
 // 記事が複数ある場合のストーリー
 export const WithPosts: Story = {


### PR DESCRIPTION
## 概要
`next build` が `src/pages` 内の `.stories.tsx` ファイルをページとして誤認識し、ビルドエラーになる問題を根本的に解決するため、全てのストーリーファイルを `src/stories` ディレクトリに移動します。

また、移動に伴い、ストーリーファイル内のコンポーネントへのインポートパスを修正しました。

これはプロジェクトの技術仕様書で定められたディレクトリ構成にも合致します。

## 変更内容
- 移動: `src/components/ArticleCard.stories.tsx` -> `src/stories/ArticleCard.stories.tsx`
- 移動: `src/components/Layout.stories.tsx` -> `src/stories/Layout.stories.tsx`
- 移動: `src/pages/index.stories.tsx` -> `src/stories/index.stories.tsx`
- 更新: `.storybook/main.ts`
  - `stories` の glob パターンを `../src/stories/**/*.stories.@(js|jsx|mjs|ts|tsx)` に更新。
- 更新: `src/stories/ArticleCard.stories.tsx`
  - `ArticleCard` コンポーネントのインポートパスを修正。
- 更新: `src/stories/Layout.stories.tsx`
  - `Layout` コンポーネントのインポートパスを修正。
- 更新: `src/stories/index.stories.tsx`
  - `HomePage` コンポーネントのインポートパスを修正。

## テスト手順
- このプルリクエストによってトリガーされる GitHub Actions のワークフロー実行結果を確認します。
- `build-and-deploy` ジョブ内の全てのステップ (特に `Build Storybook` と `Build Next.js App`) が正常に完了することを確認します。

## 関連 Issue
- (もしあれば Issue 番号を記載)