### PR TITLE
feat(next): Add basePath and assetPrefix for GitHub Pages

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,10 +1,15 @@
 /** @type {import('next').NextConfig} */
+const repoName = 'my-blog'; // Define repository name as a constant
+
 const nextConfig = {
   reactStrictMode: true,
   // Add pageExtensions to only include files ending with .tsx or .ts
   pageExtensions: ['tsx', 'ts'],
   // export 時に末尾に slash をつける
   trailingSlash: true,
+  // Set basePath and assetPrefix for GitHub Pages
+  basePath: `/${repoName}`,
+  assetPrefix: `/${repoName}/`,
   // 画像最適化機能を無効化 (GitHub Pages は SSR を持たないため)
   images: {
     unoptimized: true,


### PR DESCRIPTION
## 概要
GitHub Pages で `/<リポジトリ名>/` の形式で公開する際に発生する 404 エラーを解消するため、`next.config.js` に `basePath` と `assetPrefix` を設定します。

これにより、Next.js が生成するパスやアセットの URL に `/my-blog` が正しく付与され、GitHub Pages 上でリソースが見つかるようになります。

## 変更内容
- 更新: `next.config.js`
  - `basePath: '/my-blog'` を追加。
  - `assetPrefix: '/my-blog/'` を追加。
  - リポジトリ名を定数 `repoName` に変更。

## テスト手順
- このプルリクエストをマージ後、`main` ブランチへのプッシュによってトリガーされる GitHub Actions のワークフロー実行結果を確認します。
- デプロイ完了後、`https://sotaronishioka.github.io/my-blog/` にアクセスし、404 エラーではなくサイトが正しく表示されることを確認します。

## 関連 Issue
- (もしあれば Issue 番号を記載)