### PR TITLE
feat(ui): 基本UIコンポーネント実装 (しずかなインターネット風)

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -6,18 +6,39 @@ type ButtonProps = {
   className?: string;
   type?: 'button' | 'submit' | 'reset'; // HTMLのbutton type
   disabled?: boolean;
+  variant?: 'outline' | 'primary'; // スタイルのバリアントを追加
 };
 
-export const Button: React.FC<ButtonProps> = ({ children, onClick, className, type = 'button', disabled = false }) => {
-  // しずかなインターネット風スタイル: 枠線ベースでより控えめに
-  const baseStyle =
-    'inline-flex items-center justify-center px-4 py-2 border border-neutral-300 text-base font-medium rounded-md text-neutral-700 bg-transparent hover:bg-neutral-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-neutral-500 transition duration-150 ease-in-out';
+export const Button: React.FC<ButtonProps> = ({
+  children,
+  onClick,
+  className,
+  type = 'button',
+  disabled = false,
+  variant = 'outline', // デフォルトは 'outline'
+}) => {
+  let baseStyle = '';
+  const commonStyle =
+    'inline-flex items-center justify-center px-4 py-2 border text-base font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-neutral-500 transition duration-150 ease-in-out';
   const disabledStyle = 'disabled:opacity-50 disabled:cursor-not-allowed';
+
+  // variantに応じてスタイルを決定
+  switch (variant) {
+    case 'primary':
+      // 背景色付きボタン (例: フッターのログインボタン)
+      baseStyle = `${commonStyle} border-transparent text-white bg-neutral-800 hover:bg-neutral-700`;
+      break;
+    default: // 'outline' のスタイルをデフォルトにする
+      // 枠線ボタン
+      baseStyle = `${commonStyle} border-neutral-300 text-neutral-700 bg-transparent hover:bg-neutral-50`;
+      break;
+  }
 
   return (
     <button
       type={type}
       onClick={onClick}
+      // variantのスタイルと追加のclassNameを結合
       className={`${baseStyle} ${disabledStyle} ${className || ''}`}
       disabled={disabled}
     >

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+type ButtonProps = {
+  children: React.ReactNode;
+  onClick?: () => void;
+  className?: string;
+  type?: 'button' | 'submit' | 'reset'; // HTMLのbutton type
+  disabled?: boolean;
+};
+
+export const Button: React.FC<ButtonProps> = ({ children, onClick, className, type = 'button', disabled = false }) => {
+  // しずかなインターネット風スタイル: 枠線ベースでより控えめに
+  const baseStyle =
+    'inline-flex items-center justify-center px-4 py-2 border border-neutral-300 text-base font-medium rounded-md text-neutral-700 bg-transparent hover:bg-neutral-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-neutral-500 transition duration-150 ease-in-out';
+  const disabledStyle = 'disabled:opacity-50 disabled:cursor-not-allowed';
+
+  return (
+    <button
+      type={type}
+      onClick={onClick}
+      className={`${baseStyle} ${disabledStyle} ${className || ''}`}
+      disabled={disabled}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/components/common/Heading.tsx
+++ b/src/components/common/Heading.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+type HeadingProps = {
+  level: 1 | 2 | 3 | 4 | 5 | 6;
+  children: React.ReactNode;
+  className?: string;
+};
+
+export const Heading: React.FC<HeadingProps> = ({ level, children, className }) => {
+  const Tag = `h${level}` as keyof JSX.IntrinsicElements;
+
+  let baseStyle = '';
+  // レベルに応じてサイズ、太さ、マージンを調整
+  switch (level) {
+    case 1:
+      // ページタイトルなど、最も重要な見出し
+      baseStyle = 'text-3xl font-bold text-neutral-800 mb-8';
+      break;
+    case 2:
+      // セクションタイトルなど
+      baseStyle = 'text-2xl font-semibold text-neutral-800 mb-6 border-b pb-2'; // 下線を追加して区切りを明確に
+      break;
+    case 3:
+      // サブセクションタイトル
+      baseStyle = 'text-xl font-semibold text-neutral-800 mb-4';
+      break;
+    case 4:
+      baseStyle = 'text-lg font-semibold text-neutral-800 mb-3';
+      break;
+    // h5, h6 は必要に応じて追加するのだ
+    default:
+      baseStyle = 'text-lg font-semibold text-neutral-800 mb-3'; // h4 と同じスタイルを仮に適用
+  }
+
+  return <Tag className={`${baseStyle} ${className || ''}`}>{children}</Tag>;
+};
+
+export default Heading;

--- a/src/components/common/Link.tsx
+++ b/src/components/common/Link.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import NextLink from 'next/link'; // next/link をインポート
+
+type LinkProps = {
+  href: string;
+  children: React.ReactNode;
+  className?: string;
+  // target?: '_blank' | '_self' | '_parent' | '_top'; // target属性を追加
+  // rel?: string; // rel属性を追加
+  isExternal?: boolean; // 外部リンクかどうかを判定するフラグ
+};
+
+export const Link: React.FC<LinkProps> = ({
+  href,
+  children,
+  className,
+  // target,
+  // rel,
+  isExternal = false, // デフォルトは内部リンク
+}) => {
+  // しずかなインターネット風スタイル: 落ち着いた色合いで、ホバーは控えめに
+  const baseStyle =
+    'text-neutral-800 hover:text-neutral-600 underline decoration-neutral-300 hover:decoration-neutral-500 transition duration-150 ease-in-out';
+
+  if (isExternal || href.startsWith('http')) {
+    // isExternalフラグがtrue、またはhrefがhttp(s)で始まる場合は外部リンクとして通常のaタグを使用
+    return (
+      <a
+        href={href}
+        className={`${baseStyle} ${className || ''}`}
+        target="_blank" // 外部リンクは基本的に新しいタブで開く
+        rel="noopener noreferrer" // セキュリティ対策
+      >
+        {children}
+      </a>
+    );
+  }
+
+  // 内部リンクの場合: NextLinkに直接スタイルを適用し、子要素のaタグは削除
+  return (
+    <NextLink href={href} className={`${baseStyle} ${className || ''}`}>
+      {children}
+    </NextLink>
+  );
+};
+
+export default Link;

--- a/src/components/common/Paragraph.tsx
+++ b/src/components/common/Paragraph.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+type ParagraphProps = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+export const Paragraph: React.FC<ParagraphProps> = ({ children, className }) => {
+  const baseStyle = 'text-neutral-800 text-base leading-relaxed mb-6'; // 読みやすさと落ち着いた雰囲気を意識したスタイル
+  return <p className={`${baseStyle} ${className || ''}`}>{children}</p>;
+};
+
+export default Paragraph;

--- a/src/components/layout/BaseLayout.tsx
+++ b/src/components/layout/BaseLayout.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import Header from './Header';
+import Footer from './Footer';
+
+type BaseLayoutProps = {
+  children: React.ReactNode;
+  siteTitle?: string; // Header に渡すため
+};
+
+export const BaseLayout: React.FC<BaseLayoutProps> = ({ children, siteTitle }) => {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Header siteTitle={siteTitle} />
+      <main className="flex-grow container mx-auto px-4 py-8">{children}</main>
+      <Footer />
+    </div>
+  );
+};
+
+export default BaseLayout;

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import Link from '../common/Link';
+import Heading from '../common/Heading';
+import Paragraph from '../common/Paragraph';
+import Button from '../common/Button';
+
+export const Footer: React.FC = () => {
+  const currentYear = new Date().getFullYear();
+
+  return (
+    <footer className="mt-16 border-t border-neutral-200 pt-8 pb-12">
+      <div className="container mx-auto grid grid-cols-1 md:grid-cols-3 gap-8 px-4">
+        <div className="md:col-span-1 space-y-4">
+          <Heading level={2} className="text-lg font-semibold mb-0 border-none pb-0">
+            <Link href="/" className="text-neutral-800 hover:text-neutral-600 no-underline hover:no-underline">
+              My Blog
+            </Link>
+          </Heading>
+          <Paragraph className="text-sm text-neutral-600 mb-0">
+            日記やエッセイにちょうどいい
+            <br />
+            文章書き散らしサービス
+          </Paragraph>
+          <Button className="w-full md:w-auto bg-black text-white hover:bg-gray-800">ログイン</Button>
+        </div>
+
+        <div className="md:col-span-2 grid grid-cols-2 sm:grid-cols-3 gap-4 text-sm">
+          <div>
+            <Heading level={3} className="text-sm font-semibold text-neutral-500 mb-2 border-none pb-0">
+              ナビゲーション
+            </Heading>
+            <ul className="space-y-1">
+              <li>
+                <Link href="/" className="text-neutral-600 hover:text-neutral-800">
+                  ホーム
+                </Link>
+              </li>
+              <li>
+                <Link href="/about" className="text-neutral-600 hover:text-neutral-800">
+                  使い方
+                </Link>
+              </li>
+              <li>
+                <Link href="/tags" className="text-neutral-600 hover:text-neutral-800">
+                  タグ一覧
+                </Link>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <Heading level={3} className="text-sm font-semibold text-neutral-500 mb-2 border-none pb-0">
+              その他
+            </Heading>
+            <ul className="space-y-1">
+              <li>
+                <Link href="/privacy" className="text-neutral-600 hover:text-neutral-800">
+                  プライバシーポリシー
+                </Link>
+              </li>
+              <li>
+                <Link href="/terms" className="text-neutral-600 hover:text-neutral-800">
+                  利用規約
+                </Link>
+              </li>
+              <li>
+                <Link href="/support" className="text-neutral-600 hover:text-neutral-800">
+                  サポート
+                </Link>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <Heading level={3} className="text-sm font-semibold text-neutral-500 mb-2 border-none pb-0">
+              関連リンク
+            </Heading>
+            <ul className="space-y-1">
+              <li>
+                <Link
+                  href="https://github.com/sotaroNishioka/my-blog"
+                  isExternal
+                  className="text-neutral-600 hover:text-neutral-800"
+                >
+                  GitHub
+                </Link>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div className="container mx-auto text-center text-xs text-neutral-400 px-4 mt-8 pt-4 border-t border-neutral-100">
+        &copy; {currentYear} My Blog. All rights reserved.
+      </div>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import Link from '../common/Link'; // 作成したLinkコンポーネントを使用
+import Heading from '../common/Heading';
+
+type HeaderProps = {
+  siteTitle?: string;
+};
+
+export const Header: React.FC<HeaderProps> = ({ siteTitle = 'My Blog' }) => {
+  return (
+    <header className="border-b border-neutral-200 py-6">
+      <div className="container mx-auto px-4">
+        <Heading level={1} className="text-xl font-semibold mb-0">
+          <Link href="/" className="text-neutral-800 hover:text-neutral-600 no-underline hover:no-underline">
+            {siteTitle}
+          </Link>
+        </Heading>
+      </div>
+    </header>
+  );
+};
+
+export default Header;

--- a/src/stories/BaseLayout.stories.tsx
+++ b/src/stories/BaseLayout.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { BaseLayout } from '../components/layout/BaseLayout';
+import { Heading } from '../components/common/Heading';
+import { Paragraph } from '../components/common/Paragraph';
+
+const meta: Meta<typeof BaseLayout> = {
+  title: 'Layout/BaseLayout',
+  component: BaseLayout,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  argTypes: {
+    siteTitle: { control: 'text' },
+    // childrenは直接コントロールしない
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BaseLayout>;
+
+export const Default: Story = {
+  args: {
+    siteTitle: 'レイアウトテスト',
+    children: (
+      <>
+        <Heading level={2}>メインコンテンツエリア</Heading>
+        <Paragraph>
+          ここにページの主要なコンテンツが表示されます。
+          BaseLayoutはヘッダーとフッターを提供し、この中央部分にchildrenを配置します。
+        </Paragraph>
+        <Paragraph>コンテナは左右に適切なパディングを持ち、画面幅に応じて中央に配置されます。</Paragraph>
+      </>
+    ),
+  },
+};

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { Button } from '../components/common/Button';
+
+const meta: Meta<typeof Button> = {
+  title: 'Common/Button',
+  component: Button,
+  tags: ['autodocs'],
+  argTypes: {
+    children: { control: 'text' },
+    className: { control: 'text' },
+    disabled: { control: 'boolean' },
+    type: { control: 'select', options: ['button', 'submit', 'reset'] },
+  },
+  // Use `fn` to spy on the onClick arg, which will appear in the actions panel once invoked
+  args: { onClick: fn() },
+};
+
+export default meta;
+type Story = StoryObj<typeof Button>;
+
+export const Default: Story = {
+  args: {
+    children: 'はじめる',
+    type: "submit",
+    disabled: false,
+    className: "aa\n"
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    children: '送信中...',
+    disabled: true,
+  },
+};
+
+export const CustomClass: Story = {
+  args: {
+    children: 'カスタムボタン',
+    className: 'bg-green-500 hover:bg-green-600',
+  },
+};

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -11,6 +11,7 @@ const meta: Meta<typeof Button> = {
     className: { control: 'text' },
     disabled: { control: 'boolean' },
     type: { control: 'select', options: ['button', 'submit', 'reset'] },
+    variant: { control: 'select', options: ['outline', 'primary'] },
   },
   // Use `fn` to spy on the onClick arg, which will appear in the actions panel once invoked
   args: { onClick: fn() },
@@ -22,9 +23,9 @@ type Story = StoryObj<typeof Button>;
 export const Default: Story = {
   args: {
     children: 'はじめる',
-    type: "submit",
+    type: 'submit',
     disabled: false,
-    className: "aa\n"
+    className: 'aa\n',
   },
 };
 
@@ -39,5 +40,51 @@ export const CustomClass: Story = {
   args: {
     children: 'カスタムボタン',
     className: 'bg-green-500 hover:bg-green-600',
+  },
+};
+
+export const Outline: Story = {
+  args: {
+    children: '枠線ボタン (デフォルト)',
+    variant: 'outline',
+  },
+};
+
+export const Primary: Story = {
+  args: {
+    children: 'プライマリボタン',
+    variant: 'primary',
+  },
+};
+
+export const DisabledOutline: Story = {
+  args: {
+    children: '無効 (枠線)',
+    disabled: true,
+    variant: 'outline',
+  },
+};
+
+export const DisabledPrimary: Story = {
+  args: {
+    children: '無効 (プライマリ)',
+    disabled: true,
+    variant: 'primary',
+  },
+};
+
+export const CustomClassOutline: Story = {
+  args: {
+    children: 'カスタム枠線ボタン',
+    variant: 'outline',
+    className: 'border-red-500 text-red-500 hover:bg-red-50',
+  },
+};
+
+export const CustomClassPrimary: Story = {
+  args: {
+    children: 'カスタムプライマリボタン',
+    variant: 'primary',
+    className: 'bg-teal-600 hover:bg-teal-700',
   },
 };

--- a/src/stories/Footer.stories.tsx
+++ b/src/stories/Footer.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Footer } from '../components/layout/Footer';
+
+const meta: Meta<typeof Footer> = {
+  title: 'Layout/Footer',
+  component: Footer,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Footer>;
+
+export const Default: Story = {}; // 引数なしでデフォルト表示

--- a/src/stories/Header.stories.tsx
+++ b/src/stories/Header.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Header } from '../components/layout/Header';
+
+const meta: Meta<typeof Header> = {
+  title: 'Layout/Header',
+  component: Header,
+  tags: ['autodocs'],
+  parameters: {
+    // レイアウトコンポーネントなので、ページ全体での表示を確認しやすくする
+    layout: 'fullscreen',
+  },
+  argTypes: {
+    siteTitle: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Header>;
+
+export const Default: Story = {
+  args: {
+    siteTitle: 'しずかなブログ',
+  },
+};
+
+export const LongTitle: Story = {
+  args: {
+    siteTitle: '非常に長いサイトタイトルを持つブログの場合',
+  },
+};

--- a/src/stories/Heading.stories.tsx
+++ b/src/stories/Heading.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Heading } from '../components/common/Heading';
+
+const meta: Meta<typeof Heading> = {
+  title: 'Common/Heading',
+  component: Heading,
+  tags: ['autodocs'],
+  argTypes: {
+    level: {
+      control: { type: 'select', options: [1, 2, 3, 4, 5, 6] },
+    },
+    children: {
+      control: 'text',
+    },
+    className: {
+      control: 'text',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Heading>;
+
+export const H1: Story = {
+  args: {
+    level: 1,
+    children: 'しずかなインターネット',
+  },
+};
+
+export const H2: Story = {
+  args: {
+    level: 2,
+    children: '騒がしいインターネットの片隅に あなたの静かな場所を作りましょう',
+  },
+};
+
+export const H3: Story = {
+  args: {
+    level: 3,
+    children: 'Heading Level 3',
+  },
+};
+
+export const CustomClass: Story = {
+  args: {
+    level: 1,
+    children: 'Custom Styled H1',
+    className: 'text-purple-700 underline',
+  },
+};

--- a/src/stories/Link.stories.tsx
+++ b/src/stories/Link.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Link } from '../components/common/Link';
+
+const meta: Meta<typeof Link> = {
+  title: 'Common/Link',
+  component: Link,
+  tags: ['autodocs'],
+  argTypes: {
+    href: { control: 'text' },
+    children: { control: 'text' },
+    className: { control: 'text' },
+    isExternal: { control: 'boolean' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Link>;
+
+export const Internal: Story = {
+  args: {
+    href: '/about',
+    children: 'できることを見る',
+  },
+};
+
+export const External: Story = {
+  args: {
+    href: 'https://github.com/sotaroNishioka',
+    children: 'GitHub Profile',
+    isExternal: true, // 明示的に指定 (hrefだけでも判定される)
+  },
+};
+
+export const CustomClass: Story = {
+  args: {
+    href: '/terms',
+    children: '規約とポリシー (カスタムカラー)',
+    className: 'text-red-500 hover:text-red-700',
+  },
+};

--- a/src/stories/Paragraph.stories.tsx
+++ b/src/stories/Paragraph.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Paragraph } from '../components/common/Paragraph';
+
+const meta: Meta<typeof Paragraph> = {
+  title: 'Common/Paragraph',
+  component: Paragraph,
+  tags: ['autodocs'],
+  argTypes: {
+    children: {
+      control: 'text',
+    },
+    className: {
+      control: 'text',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Paragraph>;
+
+export const Default: Story = {
+  args: {
+    children:
+      'しずかなインターネットは、日記やエッセイを書くのにちょうどいい、文章書き散らしサービスです。ここでは有益な情報を書くことはあまり求められていません。「たくさんの人に読まれなくていい」「自分のために、ひょっとすると、どこかの誰かのために」そんな気楽さで文章を書くための場所です。',
+  },
+};
+
+export const CustomClass: Story = {
+  args: {
+    children: 'This paragraph has a custom class for text color.',
+    className: 'text-blue-600',
+  },
+};


### PR DESCRIPTION
## 概要
Issue #33 の実装として、サイト全体で利用する基本的なUIコンポーネントを「しずかなインターネット」風スタイルで実装しました。

## 変更内容
- **ディレクトリ構成:** `src/components` 以下を `common`, `features`, `layout` に分割 (Issue #36)
- **追加コンポーネント:**
    - `common/Heading.tsx`
    - `common/Paragraph.tsx`
    - `common/Button.tsx` (outline/primary variant)
    - `common/Link.tsx` (内部/外部リンク対応)
    - `layout/Header.tsx` (シンプルなタイトルヘッダー)
    - `layout/Footer.tsx` (サイト情報とナビゲーション)
    - `layout/BaseLayout.tsx` (共通ページレイアウト)
- **追加ストーリー:** 上記コンポーネントの Storybook ストーリー
- **ドキュメント更新:** `.cursor/rules/coding.mdc` のディレクトリ構成を更新

## テスト手順
1. `npm run storybook` で各コンポーネントの表示を確認
2. スタイルが意図通り適用されているか確認

Closes #33
Closes #36