### PR TITLE
feat: TOPページ (記事一覧) の改修 (#37)

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,10 @@
 import type { GetStaticProps } from 'next';
-import Layout from '@/components/Layout';
-import ArticleCard from '@/components/ArticleCard';
+// import Layout from '@/components/Layout'; // 古いLayoutを削除
+import BaseLayout from '@/components/layout/BaseLayout'; // 新しいBaseLayoutを使用
+import Heading from '@/components/common/Heading'; // Headingを使用
+import Paragraph from '@/components/common/Paragraph'; // Paragraphを使用 (日付表示用)
+import Link from '@/components/common/Link'; // Linkを使用 (タイトル用)
+// import ArticleCard from '@/components/ArticleCard'; // ArticleCardはまだないのでコメントアウト
 import { getSortedPostsData } from '@/lib/posts';
 import type { PostData } from '@/lib/posts';
 
@@ -10,16 +14,37 @@ type Props = {
 
 export default function Home({ posts }: Props) {
   return (
-    <Layout>
+    // BaseLayoutを使用
+    <BaseLayout siteTitle="My Blog">
+      {' '}
+      {/* サイトタイトルを渡す */}
       <div className="space-y-8">
-        <h1 className="text-3xl font-bold">Blog Posts</h1>
-        <div className="grid gap-6">
+        {/* Headingコンポーネントを使用 */}
+        <Heading level={1}>Blog Posts</Heading>
+        <div className="grid gap-8">
+          {' '}
+          {/* gapを少し広げる */}
           {posts.map((post) => (
-            <ArticleCard key={post.id} id={post.id} title={post.title} date={post.date} tags={post.tags} />
+            // ArticleCardの代わりに仮実装
+            <article key={post.id}>
+              <Heading level={2} className="text-xl mb-1 border-none pb-0">
+                {' '}
+                {/* 記事タイトルはh2 */}
+                <Link href={`/posts/${post.id}`}>{post.title}</Link>
+              </Heading>
+              <Paragraph className="text-sm text-neutral-500 mb-0">
+                {post.date}
+                {post.tags && post.tags.length > 0 && (
+                  <span className="ml-4">Tags: {post.tags.join(', ')}</span> // 仮のタグ表示
+                )}
+              </Paragraph>
+              {/* TODO: Issue #35 で ArticleCard コンポーネントを作成し、置き換える */}
+            </article>
+            // <ArticleCard key={post.id} id={post.id} title={post.title} date={post.date} tags={post.tags} />
           ))}
         </div>
       </div>
-    </Layout>
+    </BaseLayout>
   );
 }
 


### PR DESCRIPTION
## 概要
Issue #37 の実装として、TOPページ (`src/pages/index.tsx`) を Issue #33 で作成した新しいレイアウト (`BaseLayout`) と共通コンポーネント (`Heading`, `Link`, `Paragraph`) を使用するように改修しました。

## 変更内容
- `Layout` を `BaseLayout` に置き換え
- `h1` を `Heading` コンポーネントに置き換え
- 記事一覧部分を `ArticleCard` の代わりに仮実装 (記事タイトルリンクと日付表示)
- インポートパスにエイリアス (`@/`) を使用

## 注意点
- 記事一覧の表示は仮実装です。Issue #35 で `ArticleCard` コンポーネントを実装後、置き換える必要があります。

Closes #37