### PR TITLE
feat(ui): ユーザーページ関連コンポーネント実装 (#34)

### DIFF
--- a/src/components/features/Navigation/TabNavigation.tsx
+++ b/src/components/features/Navigation/TabNavigation.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import Link from '@/components/common/Link'; // Linkコンポーネントを使用
+
+type TabItem = {
+  label: string;
+  href: string;
+};
+
+type TabNavigationProps = {
+  tabs: TabItem[];
+  activeHref: string; // 現在アクティブなタブのhref
+  className?: string;
+};
+
+export const TabNavigation: React.FC<TabNavigationProps> = ({ tabs, activeHref, className }) => {
+  return (
+    <nav className={`border-b border-neutral-200 mb-8 ${className || ''}`}>
+      <ul className="-mb-px flex space-x-6">
+        {' '}
+        {/* -mb-px で下のボーダーを重ねる */}
+        {tabs.map((tab) => {
+          const isActive = tab.href === activeHref;
+          // アクティブなタブと非アクティブなタブでスタイルを切り替え
+          const linkClassName = `inline-block py-3 px-1 border-b-2 font-medium text-sm ${
+            isActive
+              ? 'border-neutral-800 text-neutral-800' // アクティブ時のスタイル
+              : 'border-transparent text-neutral-500 hover:text-neutral-700 hover:border-neutral-300' // 非アクティブ時のスタイル
+          }`;
+
+          return (
+            <li key={tab.href}>
+              <Link
+                href={tab.href}
+                // Linkコンポーネントのデフォルトの下線を消す
+                className={`${linkClassName} no-underline hover:no-underline`}
+              >
+                {tab.label}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+};
+
+export default TabNavigation;

--- a/src/components/features/UserProfile/UserProfileHeader.tsx
+++ b/src/components/features/UserProfile/UserProfileHeader.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import Heading from '@/components/common/Heading';
+import Paragraph from '@/components/common/Paragraph';
+// import Image from 'next/image'; // アバター用に後で追加
+
+type UserProfileHeaderProps = {
+  userName: string;
+  description?: string;
+  avatarUrl?: string; // アバター画像のURL (オプション)
+};
+
+export const UserProfileHeader: React.FC<UserProfileHeaderProps> = ({ userName, description, avatarUrl }) => {
+  return (
+    <div className="flex items-center space-x-4 border-b border-neutral-200 pb-6 mb-8">
+      {/* TODO: アバター表示を追加 */}
+      {avatarUrl && (
+        <div className="flex-shrink-0">
+          {/* <Image src={avatarUrl} alt={`${userName} avatar`} width={80} height={80} className="rounded-full" /> */}
+          <div className="w-20 h-20 rounded-full bg-neutral-200 flex items-center justify-center text-neutral-500">
+            Avatar
+          </div>{' '}
+          {/* 仮のアバタープレースホルダー */}
+        </div>
+      )}
+      <div>
+        <Heading level={1} className="text-2xl mb-1 border-none pb-0">
+          {userName}
+        </Heading>
+        {description && <Paragraph className="text-neutral-600 text-sm mb-0">{description}</Paragraph>}
+      </div>
+    </div>
+  );
+};
+
+export default UserProfileHeader;

--- a/src/stories/TabNavigation.stories.tsx
+++ b/src/stories/TabNavigation.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { TabNavigation } from '../components/features/Navigation/TabNavigation'; // パスを確認
+
+const meta: Meta<typeof TabNavigation> = {
+  title: 'Features/Navigation/TabNavigation',
+  component: TabNavigation,
+  tags: ['autodocs'],
+  argTypes: {
+    // tabsはオブジェクトの配列なので、コントロールを無効化するか、複雑なコントロールを設定
+    tabs: { control: 'object' },
+    activeHref: { control: 'text' },
+    className: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof TabNavigation>;
+
+const sampleTabs = [
+  { label: 'すべて', href: '/user/sample' },
+  { label: '日記', href: '/user/sample?tag=diary' },
+  { label: 'お知らせ', href: '/user/sample?tag=notice' },
+  { label: '技術記事', href: '/user/sample?tag=tech' },
+];
+
+export const Default: Story = {
+  args: {
+    tabs: sampleTabs,
+    activeHref: '/user/sample', // 「すべて」をアクティブに
+  },
+};
+
+export const DiaryActive: Story = {
+  args: {
+    tabs: sampleTabs,
+    activeHref: '/user/sample?tag=diary', // 「日記」をアクティブに
+  },
+};
+
+export const CustomClass: Story = {
+  args: {
+    tabs: sampleTabs,
+    activeHref: '/user/sample',
+    className: 'bg-yellow-100', // 背景色を変えてみる
+  },
+};

--- a/src/stories/UserProfileHeader.stories.tsx
+++ b/src/stories/UserProfileHeader.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { UserProfileHeader } from '../components/features/UserProfile/UserProfileHeader';
+
+const meta: Meta<typeof UserProfileHeader> = {
+  title: 'Features/UserProfile/UserProfileHeader',
+  component: UserProfileHeader,
+  tags: ['autodocs'],
+  argTypes: {
+    userName: { control: 'text' },
+    description: { control: 'text' },
+    avatarUrl: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof UserProfileHeader>;
+
+export const Default: Story = {
+  args: {
+    userName: '真緑',
+    description: '絵を描くアカウント。気まぐれにFGO中心の雑多二次創作。告知・連絡用 @mmdrbird',
+    avatarUrl: '/placeholder-avatar.png', // 仮のパス
+  },
+};
+
+export const WithoutDescription: Story = {
+  args: {
+    userName: 'シンプルユーザー',
+    avatarUrl: '/placeholder-avatar.png',
+  },
+};
+
+export const WithoutAvatar: Story = {
+  args: {
+    userName: 'アバターなしユーザー',
+    description: 'アバター画像が設定されていません。',
+  },
+};


### PR DESCRIPTION
## 概要
Issue #34 の実装として、ユーザーページで使用する以下のコンポーネントを実装しました。

## 追加コンポーネント
- `features/UserProfile/UserProfileHeader.tsx`: ユーザー名、説明、アバター（プレースホルダー）を表示するヘッダー。
- `features/Navigation/TabNavigation.tsx`: コンテンツ切り替え用のタブナビゲーション。
- 上記コンポーネントの Storybook ストーリー。

## テスト手順
1. `npm run storybook` で `Features/UserProfile/UserProfileHeader` と `Features/Navigation/TabNavigation` の表示を確認。
2. 各バリアント（アバター有無など）が意図通り表示されるか確認。

Closes #34