### PR TITLE
feat(ui): 記事詳細関連コンポーネント実装 (#35)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@storybook/test": "^8.6.12",
         "@storybook/test-runner": "^0.22.0",
         "@storybook/testing-library": "^0.2.1",
-        "@tailwindcss/typography": "^0.5.10",
+        "@tailwindcss/typography": "^0.5.16",
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^14.2.1",
         "@types/jest": "^29.5.12",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@storybook/test": "^8.6.12",
     "@storybook/test-runner": "^0.22.0",
     "@storybook/testing-library": "^0.2.1",
-    "@tailwindcss/typography": "^0.5.10",
+    "@tailwindcss/typography": "^0.5.16",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^14.2.1",
     "@types/jest": "^29.5.12",

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -18,19 +18,20 @@ export const Button: React.FC<ButtonProps> = ({
   variant = 'outline', // デフォルトは 'outline'
 }) => {
   let baseStyle = '';
+  // 共通スタイルを更新: padding, font-size, focus は削除 (variant で指定するため)
   const commonStyle =
-    'inline-flex items-center justify-center px-4 py-2 border text-base font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-neutral-500 transition duration-150 ease-in-out';
+    'inline-flex items-center justify-center border font-medium rounded-full transition duration-250 ease-in-out tracking-wider'; // rounded-full, tracking-wider, duration-250 を追加
   const disabledStyle = 'disabled:opacity-50 disabled:cursor-not-allowed';
 
   // variantに応じてスタイルを決定
   switch (variant) {
     case 'primary':
       // 背景色付きボタン (例: フッターのログインボタン)
-      baseStyle = `${commonStyle} border-transparent text-white bg-neutral-800 hover:bg-neutral-700`;
+      baseStyle =
+        'inline-flex items-center justify-center px-4 py-2 border text-base font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-neutral-500 transition duration-150 ease-in-out border-transparent text-white bg-neutral-800 hover:bg-neutral-700'; // 元のスタイルを保持
       break;
-    default: // 'outline' のスタイルをデフォルトにする
-      // 枠線ボタン
-      baseStyle = `${commonStyle} border-neutral-300 text-neutral-700 bg-transparent hover:bg-neutral-50`;
+    default: // 'outline' のスタイルをしずかなインターネット風に更新
+      baseStyle = `${commonStyle} px-6 py-3.5 text-base text-main-body bg-main-bg border-main-300 hover:bg-main-100 hover:border-main-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400`; // px, py, text, bg, border, hover, focus を更新
       break;
   }
 

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -20,7 +20,7 @@ export const Button: React.FC<ButtonProps> = ({
   let baseStyle = '';
   // 共通スタイルを更新: padding, font-size, focus は削除 (variant で指定するため)
   const commonStyle =
-    'inline-flex items-center justify-center border font-medium rounded-full transition duration-250 ease-in-out tracking-wider'; // rounded-full, tracking-wider, duration-250 を追加
+    'inline-flex items-center justify-center border font-medium rounded-full transition duration-300 ease-in-out tracking-wider'; // rounded-full, tracking-wider, duration-300 を追加
   const disabledStyle = 'disabled:opacity-50 disabled:cursor-not-allowed';
 
   // variantに応じてスタイルを決定

--- a/src/components/common/Heading.tsx
+++ b/src/components/common/Heading.tsx
@@ -10,26 +10,28 @@ export const Heading: React.FC<HeadingProps> = ({ level, children, className }) 
   const Tag = `h${level}` as keyof JSX.IntrinsicElements;
 
   let baseStyle = '';
+  const textColor = 'text-main-body'; // テキスト色を main-body に統一
+
   // レベルに応じてサイズ、太さ、マージンを調整
   switch (level) {
     case 1:
       // ページタイトルなど、最も重要な見出し
-      baseStyle = 'text-3xl font-bold text-neutral-800 mb-8';
+      baseStyle = `text-3xl font-bold ${textColor} mb-8`;
       break;
     case 2:
       // セクションタイトルなど
-      baseStyle = 'text-2xl font-semibold text-neutral-800 mb-6 border-b pb-2'; // 下線を追加して区切りを明確に
+      baseStyle = `text-2xl font-semibold ${textColor} mb-6 border-b pb-2`; // 下線を追加して区切りを明確に
       break;
     case 3:
       // サブセクションタイトル
-      baseStyle = 'text-xl font-semibold text-neutral-800 mb-4';
+      baseStyle = `text-xl font-semibold ${textColor} mb-4`;
       break;
     case 4:
-      baseStyle = 'text-lg font-semibold text-neutral-800 mb-3';
+      baseStyle = `text-lg font-semibold ${textColor} mb-3`;
       break;
     // h5, h6 は必要に応じて追加するのだ
     default:
-      baseStyle = 'text-lg font-semibold text-neutral-800 mb-3'; // h4 と同じスタイルを仮に適用
+      baseStyle = `text-lg font-semibold ${textColor} mb-3`; // h4 と同じスタイルを仮に適用
   }
 
   return <Tag className={`${baseStyle} ${className || ''}`}>{children}</Tag>;

--- a/src/components/common/Link.tsx
+++ b/src/components/common/Link.tsx
@@ -18,9 +18,9 @@ export const Link: React.FC<LinkProps> = ({
   // rel,
   isExternal = false, // デフォルトは内部リンク
 }) => {
-  // テキスト色と下線色を合わせるスタイルに変更
+  // しずかなインターネットのスタイルに合わせる
   const baseStyle =
-    'text-neutral-300 hover:text-neutral-500 underline decoration-neutral-300 hover:decoration-neutral-500 transition duration-150 ease-in-out';
+    'text-main-800 hover:text-main-600 underline decoration-main-400 hover:decoration-main-500 decoration-dotted decoration-1 underline-offset-4 transition duration-250 ease-in-out';
 
   if (isExternal || href.startsWith('http')) {
     // isExternalフラグがtrue、またはhrefがhttp(s)で始まる場合は外部リンクとして通常のaタグを使用

--- a/src/components/common/Link.tsx
+++ b/src/components/common/Link.tsx
@@ -18,9 +18,9 @@ export const Link: React.FC<LinkProps> = ({
   // rel,
   isExternal = false, // デフォルトは内部リンク
 }) => {
-  // しずかなインターネット風スタイル: 落ち着いた色合いで、ホバーは控えめに
+  // テキスト色と下線色を合わせるスタイルに変更
   const baseStyle =
-    'text-neutral-800 hover:text-neutral-600 underline decoration-neutral-300 hover:decoration-neutral-500 transition duration-150 ease-in-out';
+    'text-neutral-300 hover:text-neutral-500 underline decoration-neutral-300 hover:decoration-neutral-500 transition duration-150 ease-in-out';
 
   if (isExternal || href.startsWith('http')) {
     // isExternalフラグがtrue、またはhrefがhttp(s)で始まる場合は外部リンクとして通常のaタグを使用

--- a/src/components/common/TagBadge.tsx
+++ b/src/components/common/TagBadge.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Link from './Link'; // 同じディレクトリ内のLinkを使用
+
+type TagBadgeProps = {
+  tag: string;
+  className?: string;
+};
+
+export const TagBadge: React.FC<TagBadgeProps> = ({ tag, className }) => {
+  // TODO: slugify the tag for the URL if necessary
+  const tagUrl = `/tags/${encodeURIComponent(tag.toLowerCase())}`;
+  const baseStyle =
+    'inline-block bg-neutral-100 hover:bg-neutral-200 text-neutral-600 text-xs font-medium mr-2 px-2.5 py-0.5 rounded transition duration-150 ease-in-out';
+
+  return (
+    <Link href={tagUrl} className={`${baseStyle} ${className || ''} no-underline hover:no-underline`}>
+      {tag}
+    </Link>
+  );
+};
+
+export default TagBadge;

--- a/src/components/features/Article/ArticleBody.tsx
+++ b/src/components/features/Article/ArticleBody.tsx
@@ -1,23 +1,20 @@
-import React from 'react';
+import React, { FC } from 'react';
+import { marked } from 'marked';
 
-type ArticleBodyProps = {
-  contentHtml: string; // Markdownから変換されたHTML文字列
-  className?: string;
-};
+interface ArticleBodyProps {
+  /** Markdown形式の本文 */
+  markdownContent: string;
+}
 
-export const ArticleBody: React.FC<ArticleBodyProps> = ({ contentHtml, className }) => {
-  // TODO: Tailwind Typography プラグインを導入して適用する
-  const proseStyle = 'prose lg:prose-xl max-w-none'; // Typographyプラグイン用のクラス (仮)
+/**
+ * Markdown形式の本文を表示するコンポーネント
+ * @param markdownContent - 表示するMarkdownコンテンツ
+ */
+export const ArticleBody: FC<ArticleBodyProps> = ({ markdownContent }) => {
+  const htmlContent = marked.parse(markdownContent);
 
-  return (
-    <div
-      className={`${proseStyle} ${className || ''}`}
-      // MarkdownからのHTMLを安全に表示するためdangerouslySetInnerHTMLを使用
-      // サニタイズはmarked側で行う前提
-      // eslint-disable-next-line react/no-danger
-      dangerouslySetInnerHTML={{ __html: contentHtml }}
-    />
-  );
+  // biome-ignore lint/security/noDangerouslySetInnerHtml: <explanation>
+  return <div className="prose" dangerouslySetInnerHTML={{ __html: htmlContent }} />;
 };
 
 export default ArticleBody;

--- a/src/components/features/Article/ArticleBody.tsx
+++ b/src/components/features/Article/ArticleBody.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+type ArticleBodyProps = {
+  contentHtml: string; // Markdownから変換されたHTML文字列
+  className?: string;
+};
+
+export const ArticleBody: React.FC<ArticleBodyProps> = ({ contentHtml, className }) => {
+  // TODO: Tailwind Typography プラグインを導入して適用する
+  const proseStyle = 'prose lg:prose-xl max-w-none'; // Typographyプラグイン用のクラス (仮)
+
+  return (
+    <div
+      className={`${proseStyle} ${className || ''}`}
+      // MarkdownからのHTMLを安全に表示するためdangerouslySetInnerHTMLを使用
+      // サニタイズはmarked側で行う前提
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: contentHtml }}
+    />
+  );
+};
+
+export default ArticleBody;

--- a/src/components/features/Article/ArticleCard.tsx
+++ b/src/components/features/Article/ArticleCard.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import Link from '@/components/common/Link';
+import Heading from '@/components/common/Heading';
+import Paragraph from '@/components/common/Paragraph';
+import TagBadge from '@/components/common/TagBadge';
+
+// posts.ts から Omit<PostData, 'contentHtml'> をインポートしたいが、一旦定義
+// TODO: src/types/index.ts などで共通化を検討
+type ArticleCardProps = {
+  id: string;
+  title: string;
+  date: string;
+  tags?: string[];
+};
+
+export const ArticleCard: React.FC<ArticleCardProps> = ({ id, title, date, tags }) => {
+  return (
+    <article className="border border-neutral-200 rounded-lg p-6 hover:shadow-md transition-shadow duration-200">
+      <Heading level={2} className="text-xl mb-2 border-none pb-0">
+        <Link href={`/posts/${id}`}>{title}</Link>
+      </Heading>
+      <Paragraph className="text-sm text-neutral-500 mb-4">
+        <time dateTime={date}>{date}</time>
+      </Paragraph>
+      {tags && tags.length > 0 && (
+        <div className="mt-2">
+          {tags.map((tag) => (
+            <TagBadge key={tag} tag={tag} />
+          ))}
+        </div>
+      )}
+    </article>
+  );
+};
+
+export default ArticleCard;

--- a/src/components/features/Article/ArticleHeader.tsx
+++ b/src/components/features/Article/ArticleHeader.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import Heading from '@/components/common/Heading';
+import Link from '@/components/common/Link';
+import Paragraph from '@/components/common/Paragraph';
+// import Image from 'next/image'; // 著者アバター用に後で検討
+
+type ArticleHeaderProps = {
+  title: string;
+  authorName: string;
+  authorLink: string; // 著者ページへのリンク
+  publishedDate: string;
+  authorAvatarUrl?: string; // オプションのアバター
+};
+
+export const ArticleHeader: React.FC<ArticleHeaderProps> = ({
+  title,
+  authorName,
+  authorLink,
+  publishedDate,
+  authorAvatarUrl,
+}) => {
+  return (
+    <div className="mb-8 border-b border-neutral-200 pb-6">
+      <Heading level={1} className="text-3xl md:text-4xl font-bold mb-4">
+        {title}
+      </Heading>
+      <div className="flex items-center text-sm text-neutral-500 space-x-3">
+        {authorAvatarUrl && (
+          <div className="flex-shrink-0">
+            {/* アバター表示 (仮) */}
+            <div className="w-8 h-8 rounded-full bg-neutral-200" />
+          </div>
+        )}
+        <div>
+          <Link href={authorLink} className="font-medium text-neutral-700 hover:text-neutral-900">
+            {authorName}
+          </Link>
+          <span className="mx-2">·</span>
+          <time dateTime={publishedDate}>{publishedDate}</time>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ArticleHeader;

--- a/src/components/features/Article/ArticleTags.tsx
+++ b/src/components/features/Article/ArticleTags.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import TagBadge from '@/components/common/TagBadge'; // 作成したTagBadgeを使用
+
+type ArticleTagsProps = {
+  tags: string[];
+  className?: string;
+};
+
+export const ArticleTags: React.FC<ArticleTagsProps> = ({ tags, className }) => {
+  if (!tags || tags.length === 0) {
+    return null; // タグがなければ何も表示しない
+  }
+
+  return (
+    <div className={`mt-6 mb-4 ${className || ''}`}>
+      {' '}
+      {/* 少し上下にマージン */}
+      {tags.map((tag) => (
+        <TagBadge key={tag} tag={tag} />
+      ))}
+    </div>
+  );
+};
+
+export default ArticleTags;

--- a/src/components/features/Article/AuthorProfile.tsx
+++ b/src/components/features/Article/AuthorProfile.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import Link from '@/components/common/Link';
+import Paragraph from '@/components/common/Paragraph';
+// import Image from 'next/image';
+
+type AuthorProfileProps = {
+  authorName: string;
+  authorLink: string;
+  avatarUrl?: string;
+  description?: string;
+  // snsLinks?: { platform: string; url: string }[]; // 将来的にSNSリンクなどを追加
+};
+
+export const AuthorProfile: React.FC<AuthorProfileProps> = ({ authorName, authorLink, avatarUrl, description }) => {
+  return (
+    <div className="mt-12 pt-8 border-t border-neutral-200 flex items-start space-x-4">
+      {/* アバター */}
+      <div className="flex-shrink-0">
+        <Link href={authorLink} className="block">
+          {avatarUrl ? (
+            // <Image src={avatarUrl} alt={authorName} width={56} height={56} className="rounded-full" />
+            <div className="w-14 h-14 rounded-full bg-neutral-200" /> // 仮 & 自己終了タグ
+          ) : (
+            <div className="w-14 h-14 rounded-full bg-neutral-200 flex items-center justify-center text-neutral-500 text-xs">
+              No Avatar
+            </div>
+          )}
+        </Link>
+      </div>
+
+      {/* 名前と説明 */}
+      <div className="flex-grow">
+        <Link
+          href={authorLink}
+          className="text-lg font-semibold text-neutral-800 hover:text-neutral-600 no-underline hover:no-underline"
+        >
+          {authorName}
+        </Link>
+        {description && <Paragraph className="text-sm text-neutral-600 mt-1 mb-0">{description}</Paragraph>}
+        {/* TODO: SNSリンクなどを表示 */}
+      </div>
+    </div>
+  );
+};
+
+export default AuthorProfile;

--- a/src/stories/ArticleBody.stories.tsx
+++ b/src/stories/ArticleBody.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ArticleBody } from '../components/features/Article/ArticleBody';
+
+const meta: Meta<typeof ArticleBody> = {
+  title: 'Features/Article/ArticleBody',
+  component: ArticleBody,
+  tags: ['autodocs'],
+  argTypes: {
+    contentHtml: { control: 'text' },
+    className: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ArticleBody>;
+
+const sampleHtmlContent = `
+<h2>これは H2 見出しです</h2>
+<p>これは通常の段落です。<strong>太字</strong>や<em>イタリック</em>も含まれます。</p>
+<ul>
+  <li>リストアイテム 1</li>
+  <li>リストアイテム 2</li>
+</ul>
+<blockquote>
+  <p>これは引用ブロックです。</p>
+</blockquote>
+<pre><code class="language-javascript">// これはコードブロックです
+console.log('Hello, world!');
+</code></pre>
+<p>リンクも表示できます: <a href="https://example.com">Example Link</a></p>
+`;
+
+export const Default: Story = {
+  args: {
+    contentHtml: sampleHtmlContent,
+  },
+};
+
+export const WithCustomClass: Story = {
+  args: {
+    contentHtml: '<p>このコンテンツには追加のクラスが適用されています。</p>',
+    className: 'bg-blue-100 p-4 rounded',
+  },
+};

--- a/src/stories/ArticleBody.stories.tsx
+++ b/src/stories/ArticleBody.stories.tsx
@@ -6,39 +6,40 @@ const meta: Meta<typeof ArticleBody> = {
   component: ArticleBody,
   tags: ['autodocs'],
   argTypes: {
-    contentHtml: { control: 'text' },
-    className: { control: 'text' },
+    markdownContent: { control: 'text' },
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof ArticleBody>;
 
-const sampleHtmlContent = `
-<h2>これは H2 見出しです</h2>
-<p>これは通常の段落です。<strong>太字</strong>や<em>イタリック</em>も含まれます。</p>
-<ul>
-  <li>リストアイテム 1</li>
-  <li>リストアイテム 2</li>
-</ul>
-<blockquote>
-  <p>これは引用ブロックです。</p>
-</blockquote>
-<pre><code class="language-javascript">// これはコードブロックです
+const sampleMarkdownContent = `
+## これは H2 見出しです
+
+これは通常の段落です。**太字**や*イタリック*も含まれます。
+
+- リストアイテム 1
+- リストアイテム 2
+
+> これは引用ブロックです。
+
+\`\`\`javascript
+// これはコードブロックです
 console.log('Hello, world!');
-</code></pre>
-<p>リンクも表示できます: <a href="https://example.com">Example Link</a></p>
+\`\`\`
+
+リンクも表示できます: [Example Link](https://example.com)
 `;
 
 export const Default: Story = {
   args: {
-    contentHtml: sampleHtmlContent,
+    markdownContent: sampleMarkdownContent,
   },
 };
 
-export const WithCustomClass: Story = {
-  args: {
-    contentHtml: '<p>このコンテンツには追加のクラスが適用されています。</p>',
-    className: 'bg-blue-100 p-4 rounded',
-  },
-};
+// export const WithCustomClass: Story = {
+//   args: {
+//     markdownContent: 'このコンテンツには追加のクラスが適用されています。',
+//     className: 'bg-blue-100 p-4 rounded',
+//   },
+// };

--- a/src/stories/ArticleCard.stories.tsx
+++ b/src/stories/ArticleCard.stories.tsx
@@ -1,75 +1,44 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { within, expect } from '@storybook/test';
-import ArticleCard from '../components/ArticleCard';
-import { PostData } from '../lib/posts';
-
-// モックデータ (Home.test.tsx などから拝借)
-const mockArticleData = {
-  id: 'test-story-post',
-  title: 'Storybook Test Post Title',
-  date: '2024-07-28',
-  tags: ['storybook', 'testing'],
-};
+import { ArticleCard } from '../components/features/Article/ArticleCard';
 
 const meta: Meta<typeof ArticleCard> = {
-  title: 'Components/ArticleCard',
+  title: 'Features/Article/ArticleCard',
   component: ArticleCard,
-  parameters: {
-    layout: 'centered', // カードなので中央表示が良いかも
-  },
   tags: ['autodocs'],
   argTypes: {
-    // Propsの型は自動で推論されることが多いが、明示しても良い
     id: { control: 'text' },
     title: { control: 'text' },
     date: { control: 'text' },
     tags: { control: 'object' },
   },
-  args: mockArticleData, // Default args for the story
 };
 
 export default meta;
 type Story = StoryObj<typeof ArticleCard>;
 
-// 基本的な表示のストーリー
 export const Default: Story = {
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    // 記事タイトルが表示されているか
-    const title = await canvas.findByRole('heading', { name: mockArticleData.title });
-    expect(title).toBeInTheDocument();
-
-    // 日付が表示されているか
-    const date = await canvas.findByText(mockArticleData.date);
-    expect(date).toBeInTheDocument();
-
-    // タグが表示されているか
-    const tag1 = await canvas.findByText(mockArticleData.tags[0]);
-    expect(tag1).toBeInTheDocument();
-    const tag2 = await canvas.findByText(mockArticleData.tags[1]);
-    expect(tag2).toBeInTheDocument();
-
-    // リンクが正しいか (href属性を確認)
-    const link = await canvas.findByRole('link');
-    expect(link).toHaveAttribute('href', `/posts/${mockArticleData.id}`);
+  args: {
+    id: 'test-post-1',
+    title: '最初のテスト投稿',
+    date: '2024-01-01',
+    tags: ['Next.js', 'TypeScript'],
   },
 };
 
-// タグがない場合のストーリー (オプション)
 export const WithoutTags: Story = {
   args: {
-    ...mockArticleData,
-    tags: [],
+    id: 'test-post-2',
+    title: 'タグのない投稿',
+    date: '2024-01-02',
+    // tags を指定しない
   },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    // タグ要素が存在しないことを確認 (タグのコンテナ要素のセレクタなどを使うとより確実)
-    const tagElements = canvas.queryAllByText(/^storybook$|^testing$/i); // 例: テキストで探す
-    expect(tagElements).toHaveLength(0);
+};
 
-    // 他の要素は表示されていることを確認
-    const title = await canvas.findByRole('heading', { name: mockArticleData.title });
-    expect(title).toBeInTheDocument();
+export const LongTitle: Story = {
+  args: {
+    id: 'test-post-3',
+    title: 'これは非常に長い記事のタイトルで、カード内でどのように表示されるかを確認するためのものです',
+    date: '2024-01-03',
+    tags: ['テスト'],
   },
 };

--- a/src/stories/ArticleHeader.stories.tsx
+++ b/src/stories/ArticleHeader.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ArticleHeader } from '../components/features/Article/ArticleHeader'; // ../ になっているはずだが再確認・修正
+
+const meta: Meta<typeof ArticleHeader> = {
+  title: 'Features/Article/ArticleHeader',
+  component: ArticleHeader,
+  tags: ['autodocs'],
+  argTypes: {
+    title: { control: 'text' },
+    authorName: { control: 'text' },
+    authorLink: { control: 'text' },
+    publishedDate: { control: 'text' },
+    authorAvatarUrl: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ArticleHeader>;
+
+export const Default: Story = {
+  args: {
+    title: 'そうだ、SAITAMA行こう。',
+    authorName: '真緑',
+    authorLink: '/mmdrbird', // 仮のリンク
+    publishedDate: '2025-04-21',
+    authorAvatarUrl: '/placeholder-avatar.png', // 仮のアバター
+  },
+};
+
+export const WithoutAvatar: Story = {
+  args: {
+    title: 'アバターなしの記事ヘッダー',
+    authorName: 'テストユーザー',
+    authorLink: '/test-user',
+    publishedDate: '2024-01-01',
+    // authorAvatarUrl を指定しない
+  },
+};
+
+export const LongTitle: Story = {
+  args: {
+    title: 'これは非常に、非常に、本当に非常に長い記事のタイトルであり、複数行に折り返される可能性があります',
+    authorName: '真緑',
+    authorLink: '/mmdrbird',
+    publishedDate: '2025-04-21',
+    authorAvatarUrl: '/placeholder-avatar.png',
+  },
+};

--- a/src/stories/ArticleTags.stories.tsx
+++ b/src/stories/ArticleTags.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ArticleTags } from '../components/features/Article/ArticleTags';
+
+const meta: Meta<typeof ArticleTags> = {
+  title: 'Features/Article/ArticleTags',
+  component: ArticleTags,
+  tags: ['autodocs'],
+  argTypes: {
+    tags: { control: 'object' },
+    className: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ArticleTags>;
+
+export const Default: Story = {
+  args: {
+    tags: ['落書き', '日記', 'FGO'],
+  },
+};
+
+export const SingleTag: Story = {
+  args: {
+    tags: ['お知らせ'],
+  },
+};
+
+export const NoTags: Story = {
+  args: {
+    tags: [],
+  },
+};
+
+export const WithCustomClass: Story = {
+  args: {
+    tags: ['タグ1', 'タグ2'],
+    className: 'border-t border-dashed pt-4',
+  },
+};

--- a/src/stories/AuthorProfile.stories.tsx
+++ b/src/stories/AuthorProfile.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { AuthorProfile } from '../components/features/Article/AuthorProfile';
+
+const meta: Meta<typeof AuthorProfile> = {
+  title: 'Features/Article/AuthorProfile',
+  component: AuthorProfile,
+  tags: ['autodocs'],
+  argTypes: {
+    authorName: { control: 'text' },
+    authorLink: { control: 'text' },
+    avatarUrl: { control: 'text' },
+    description: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof AuthorProfile>;
+
+export const Default: Story = {
+  args: {
+    authorName: '真緑',
+    authorLink: '/mmdrbird',
+    avatarUrl: '/placeholder-avatar.png',
+    description: '絵を描くアカウント。気まぐれにFGO中心の雑多二次創作。告知・連絡用 @mmdrbird',
+  },
+};
+
+export const WithoutDescription: Story = {
+  args: {
+    authorName: 'シンプルユーザー',
+    authorLink: '/simple-user',
+    avatarUrl: '/placeholder-avatar.png',
+  },
+};
+
+export const WithoutAvatar: Story = {
+  args: {
+    authorName: 'アバターなしユーザー',
+    authorLink: '/no-avatar-user',
+    description: '簡単な自己紹介文。',
+  },
+};

--- a/src/stories/TagBadge.stories.tsx
+++ b/src/stories/TagBadge.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { TagBadge } from '../components/common/TagBadge';
+
+const meta: Meta<typeof TagBadge> = {
+  title: 'Common/TagBadge',
+  component: TagBadge,
+  tags: ['autodocs'],
+  argTypes: {
+    tag: { control: 'text' },
+    className: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof TagBadge>;
+
+export const Default: Story = {
+  args: {
+    tag: '日記',
+  },
+};
+
+export const LongTag: Story = {
+  args: {
+    tag: 'tailwindcss',
+  },
+};
+
+export const WithCustomClass: Story = {
+  args: {
+    tag: 'カスタム',
+    className: 'bg-blue-100 text-blue-800 hover:bg-blue-200',
+  },
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,17 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ['./src/pages/**/*.{js,ts,jsx,tsx}', './src/components/**/*.{js,ts,jsx,tsx}'],
+  content: [
+    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
+  ],
   theme: {
-    extend: {},
+    extend: {
+      backgroundImage: {
+        'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
+        'gradient-conic': 'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
+      },
+    },
   },
   plugins: [require('@tailwindcss/typography')],
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,14 @@ module.exports = {
   ],
   theme: {
     extend: {
+      colors: {
+        main: {
+          800: '#595f63',
+          600: '#798184',
+          500: '#8d9298',
+          400: '#a7abb1',
+        },
+      },
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
         'gradient-conic': 'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
@@ -33,7 +41,7 @@ module.exports = {
               '@apply text-lg font-semibold text-neutral-800 mb-3': {},
             },
             a: {
-              '@apply text-neutral-300 hover:text-neutral-500 underline decoration-neutral-300 hover:decoration-neutral-500 transition duration-150 ease-in-out':
+              '@apply text-main-800 hover:text-main-600 underline decoration-main-400 hover:decoration-main-500 decoration-dotted decoration-1 underline-offset-4 transition duration-250 ease-in-out':
                 {},
               textDecoration: 'underline',
               fontWeight: 'inherit',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -33,7 +33,7 @@ module.exports = {
               '@apply text-lg font-semibold text-neutral-800 mb-3': {},
             },
             a: {
-              '@apply text-neutral-800 hover:text-neutral-600 underline decoration-neutral-300 hover:decoration-neutral-500 transition duration-150 ease-in-out':
+              '@apply text-neutral-300 hover:text-neutral-500 underline decoration-neutral-300 hover:decoration-neutral-500 transition duration-150 ease-in-out':
                 {},
               textDecoration: 'underline',
               fontWeight: 'inherit',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,6 +13,10 @@ module.exports = {
           600: '#798184',
           500: '#8d9298',
           400: '#a7abb1',
+          300: '#d8dadf',
+          100: '#f1f6f9',
+          body: 'rgba(3, 10, 18, .81)',
+          bg: '#fff',
         },
       },
       backgroundImage: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,6 +11,37 @@ module.exports = {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
         'gradient-conic': 'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
       },
+      typography: (theme) => ({
+        DEFAULT: {
+          css: {
+            h1: {
+              '@apply text-3xl font-bold text-neutral-800 mb-8': {},
+            },
+            h2: {
+              '@apply text-2xl font-semibold text-neutral-800 mb-6 border-b pb-2': {},
+            },
+            h3: {
+              '@apply text-xl font-semibold text-neutral-800 mb-4': {},
+            },
+            h4: {
+              '@apply text-lg font-semibold text-neutral-800 mb-3': {},
+            },
+            h5: {
+              '@apply text-lg font-semibold text-neutral-800 mb-3': {},
+            },
+            h6: {
+              '@apply text-lg font-semibold text-neutral-800 mb-3': {},
+            },
+            a: {
+              '@apply text-neutral-800 hover:text-neutral-600 underline decoration-neutral-300 hover:decoration-neutral-500 transition duration-150 ease-in-out':
+                {},
+              textDecoration: 'underline',
+              fontWeight: 'inherit',
+            },
+            p: {},
+          },
+        },
+      }),
     },
   },
   plugins: [require('@tailwindcss/typography')],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -45,7 +45,7 @@ module.exports = {
               '@apply text-lg font-semibold text-main-body mb-3': {},
             },
             a: {
-              '@apply text-main-800 hover:text-main-600 underline decoration-main-400 hover:decoration-main-500 decoration-dotted decoration-1 underline-offset-4 transition duration-250 ease-in-out':
+              '@apply text-main-800 hover:text-main-600 underline decoration-main-400 hover:decoration-main-500 decoration-dotted decoration-1 underline-offset-4 transition duration-300 ease-in-out':
                 {},
               textDecoration: 'underline',
               fontWeight: 'inherit',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -27,22 +27,22 @@ module.exports = {
         DEFAULT: {
           css: {
             h1: {
-              '@apply text-3xl font-bold text-neutral-800 mb-8': {},
+              '@apply text-3xl font-bold text-main-body mb-8': {},
             },
             h2: {
-              '@apply text-2xl font-semibold text-neutral-800 mb-6 border-b pb-2': {},
+              '@apply text-2xl font-semibold text-main-body mb-6 border-b pb-2': {},
             },
             h3: {
-              '@apply text-xl font-semibold text-neutral-800 mb-4': {},
+              '@apply text-xl font-semibold text-main-body mb-4': {},
             },
             h4: {
-              '@apply text-lg font-semibold text-neutral-800 mb-3': {},
+              '@apply text-lg font-semibold text-main-body mb-3': {},
             },
             h5: {
-              '@apply text-lg font-semibold text-neutral-800 mb-3': {},
+              '@apply text-lg font-semibold text-main-body mb-3': {},
             },
             h6: {
-              '@apply text-lg font-semibold text-neutral-800 mb-3': {},
+              '@apply text-lg font-semibold text-main-body mb-3': {},
             },
             a: {
               '@apply text-main-800 hover:text-main-600 underline decoration-main-400 hover:decoration-main-500 decoration-dotted decoration-1 underline-offset-4 transition duration-250 ease-in-out':
@@ -50,7 +50,9 @@ module.exports = {
               textDecoration: 'underline',
               fontWeight: 'inherit',
             },
-            p: {},
+            p: {
+              '@apply text-main-body': {},
+            },
           },
         },
       }),


### PR DESCRIPTION
## 概要
Issue #35 の実装として、記事詳細ページで使用する以下のコンポーネントと、記事一覧で使用する `ArticleCard` を実装しました。

## 追加コンポーネント
- `common/TagBadge.tsx`: タグ表示用のバッジ
- `features/Article/ArticleHeader.tsx`: 記事タイトル、著者、日付
- `features/Article/ArticleBody.tsx`: Markdown コンテンツ表示エリア
- `features/Article/ArticleTags.tsx`: 記事タグ一覧
- `features/Article/AuthorProfile.tsx`: 記事下の著者プロフィール
- `features/Article/ArticleCard.tsx`: 記事一覧用のカード
- 上記コンポーネントの Storybook ストーリー

## 備考
- `ArticleBody` は Tailwind Typography プラグインの適用を推奨します (別途対応)。
- `AuthorProfile` は `UserProfileHeader` (Issue #34) との共通化を今後検討可能です。

## テスト手順
1. `npm run storybook` で追加されたコンポーネントの表示を確認。

Closes #35