### PR TITLE
feat: 著者別記事一覧ページの実装

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -8,7 +8,15 @@
     "rules": {
       "recommended": true
     },
-    "ignore": [".next/**", "node_modules/**", "public/**", ".github/**", "posts/**/*.md"]
+    "ignore": [
+      ".next/**",
+      "node_modules/**",
+      "public/**",
+      ".github/**",
+      "posts/**/*.md",
+      "storybook-static/**",
+      "out/**"
+    ]
   },
   "formatter": {
     "enabled": true,
@@ -16,7 +24,15 @@
     "indentStyle": "space",
     "indentWidth": 2,
     "lineWidth": 120,
-    "ignore": [".next/**", "node_modules/**", "public/**", ".github/**", "posts/**/*.md"]
+    "ignore": [
+      ".next/**",
+      "node_modules/**",
+      "public/**",
+      ".github/**",
+      "posts/**/*.md",
+      "storybook-static/**",
+      "out/**"
+    ]
   },
   "javascript": {
     "formatter": {

--- a/posts/2024-02-15-hello-world.md
+++ b/posts/2024-02-15-hello-world.md
@@ -2,6 +2,7 @@
 title: "Hello, World!"
 date: "2024-02-15"
 tags: ["nextjs", "github-pages", "typescript"]
+author: "Author Two"
 ---
 
 # Next.js と TypeScript でブログを作ってみた

--- a/posts/test-author1-another.md
+++ b/posts/test-author1-another.md
@@ -1,0 +1,8 @@
+---
+title: 'Another Test Post Author 1'
+date: '2024-01-04'
+tags: ['test', 'author1', 'another']
+author: 'Author One'
+---
+
+This is another test post by Author One. 

--- a/src/__tests__/fixtures/posts/test-author1.md
+++ b/src/__tests__/fixtures/posts/test-author1.md
@@ -1,0 +1,8 @@
+---
+title: 'Test Post Author 1'
+date: '2024-01-01'
+tags: ['test', 'author1']
+author: 'Author One'
+---
+
+This is a test post by Author One for testing purposes. 

--- a/src/__tests__/fixtures/posts/test-author2.md
+++ b/src/__tests__/fixtures/posts/test-author2.md
@@ -1,0 +1,8 @@
+---
+title: 'Test Post Author 2'
+date: '2024-01-02'
+tags: ['test', 'author2']
+author: 'Author Two'
+---
+
+This is a test post by Author Two for testing purposes. 

--- a/src/__tests__/lib/posts.test.ts
+++ b/src/__tests__/lib/posts.test.ts
@@ -1,0 +1,90 @@
+import { getAllAuthorIds, getAuthorNameFromId, getPostsByAuthor } from '@/lib/posts';
+
+// モックファイルシステム
+jest.mock('node:fs', () => ({
+  readdirSync: jest.fn(() => ['test-author1.md', 'test-author2.md']),
+  readFileSync: jest.fn((path) => {
+    if (path.includes('test-author1.md')) {
+      return `---
+title: 'Test Post Author 1'
+date: '2024-01-01'
+tags: ['test', 'author1']
+author: 'Author One'
+---
+Test content 1`;
+    }
+    if (path.includes('test-author2.md')) {
+      return `---
+title: 'Test Post Author 2'
+date: '2024-01-02'
+tags: ['test', 'author2']
+author: 'Author Two'
+---
+Test content 2`;
+    }
+    throw new Error(`File not found: ${path}`);
+  }),
+}));
+
+// jest.mockされたモジュールの型を解決するためのアサーション
+const fs = jest.requireMock('node:fs');
+
+describe('posts.ts - 著者関連機能', () => {
+  beforeEach(() => {
+    // モックのリセット
+    jest.clearAllMocks();
+  });
+
+  describe('getAllAuthorIds', () => {
+    it('すべての著者IDを取得できること', () => {
+      const result = getAllAuthorIds();
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        // 順序が重要でないため、配列の要素がすべて含まれているかをチェック
+        expect(result.value).toHaveLength(2);
+        expect(result.value).toEqual(
+          expect.arrayContaining([{ params: { authorId: 'author-one' } }, { params: { authorId: 'author-two' } }])
+        );
+      }
+
+      // ファイル読み込みが呼ばれたことの確認
+      expect(fs.readdirSync).toHaveBeenCalled();
+      expect(fs.readFileSync).toHaveBeenCalled();
+    });
+  });
+
+  describe('getAuthorNameFromId', () => {
+    it('著者IDから著者名を取得できること', () => {
+      const authorName = getAuthorNameFromId('author-one');
+      expect(authorName).toBe('author one');
+    });
+
+    it('空白を含む著者IDを正しく処理できること', () => {
+      const authorName = getAuthorNameFromId('author-with-multiple-words');
+      expect(authorName).toBe('author with multiple words');
+    });
+  });
+
+  describe('getPostsByAuthor', () => {
+    it('特定の著者の記事を取得できること', () => {
+      const result = getPostsByAuthor('author-one');
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toHaveLength(1);
+        expect(result.value[0].title).toBe('Test Post Author 1');
+        expect(result.value[0].author).toBe('Author One');
+      }
+    });
+
+    it('存在しない著者の場合は空の配列を返すこと', () => {
+      const result = getPostsByAuthor('non-existent-author');
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toHaveLength(0);
+      }
+    });
+  });
+});

--- a/src/__tests__/lib/posts.test.ts
+++ b/src/__tests__/lib/posts.test.ts
@@ -1,30 +1,30 @@
+import path from 'path';
 import { getAllAuthorIds, getAuthorNameFromId, getPostsByAuthor } from '@/lib/posts';
 
 // モックファイルシステム
-jest.mock('node:fs', () => ({
-  readdirSync: jest.fn(() => ['test-author1.md', 'test-author2.md']),
-  readFileSync: jest.fn((path) => {
-    if (path.includes('test-author1.md')) {
-      return `---
-title: 'Test Post Author 1'
-date: '2024-01-01'
-tags: ['test', 'author1']
-author: 'Author One'
----
-Test content 1`;
-    }
-    if (path.includes('test-author2.md')) {
-      return `---
-title: 'Test Post Author 2'
-date: '2024-01-02'
-tags: ['test', 'author2']
-author: 'Author Two'
----
-Test content 2`;
-    }
-    throw new Error(`File not found: ${path}`);
-  }),
-}));
+jest.mock('node:fs', () => {
+  const originalFs = jest.requireActual('node:fs');
+  const testFixturesPath = path.join(process.cwd(), 'src/__tests__/fixtures');
+
+  return {
+    readdirSync: jest.fn((dirPath) => {
+      // postsディレクトリへの参照をテストフィクスチャディレクトリに置き換える
+      if (dirPath.includes('/posts')) {
+        return originalFs.readdirSync(path.join(testFixturesPath, 'posts'));
+      }
+      return originalFs.readdirSync(dirPath);
+    }),
+    readFileSync: jest.fn((filePath, encoding) => {
+      // postsディレクトリへの参照をテストフィクスチャディレクトリに置き換える
+      if (filePath.includes('/posts/')) {
+        const fileName = path.basename(filePath);
+        const testPath = path.join(testFixturesPath, 'posts', fileName);
+        return originalFs.readFileSync(testPath, encoding);
+      }
+      return originalFs.readFileSync(filePath, encoding);
+    }),
+  };
+});
 
 // jest.mockされたモジュールの型を解決するためのアサーション
 const fs = jest.requireMock('node:fs');

--- a/src/__tests__/pages/author.test.tsx
+++ b/src/__tests__/pages/author.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import AuthorPage from '@/pages/author/[authorId]';
+import { PostData } from '@/lib/posts';
+
+// モックコンポーネント
+jest.mock('@/components/layout/BaseLayout', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <div data-testid="mock-layout">{children}</div>,
+}));
+
+jest.mock('@/components/features/UserProfile/UserProfileHeader', () => ({
+  __esModule: true,
+  default: ({ userName, description }: { userName: string; description?: string }) => (
+    <div data-testid="mock-user-profile">
+      <h1>{userName}</h1>
+      {description && <p>{description}</p>}
+    </div>
+  ),
+}));
+
+jest.mock('@/components/features/Navigation/TabNavigation', () => ({
+  __esModule: true,
+  default: ({ tabs, activeHref }: { tabs: { label: string; href: string }[]; activeHref: string }) => (
+    <nav data-testid="mock-tab-navigation">
+      <ul>
+        {tabs.map((tab) => (
+          <li key={tab.href} data-active={tab.href === activeHref ? 'true' : 'false'}>
+            {tab.label}
+          </li>
+        ))}
+      </ul>
+    </nav>
+  ),
+}));
+
+jest.mock('@/components/features/Article/ArticleList', () => ({
+  __esModule: true,
+  default: ({ articles }: { articles: Omit<PostData, 'contentHtml'>[] }) => (
+    <div data-testid="mock-article-list">
+      <span>記事数: {articles.length}</span>
+      <ul>
+        {articles.map((article) => (
+          <li key={article.id}>{article.title}</li>
+        ))}
+      </ul>
+    </div>
+  ),
+}));
+
+describe('AuthorPage', () => {
+  const mockProps = {
+    authorName: 'テスト著者',
+    authorId: 'test-author',
+    posts: [
+      {
+        id: 'test-post-1',
+        title: 'テスト記事1',
+        date: '2024-01-01',
+        tags: ['test'],
+        author: 'テスト著者',
+      },
+      {
+        id: 'test-post-2',
+        title: 'テスト記事2',
+        date: '2024-01-02',
+        tags: ['test'],
+        author: 'テスト著者',
+      },
+    ],
+  };
+
+  it('著者情報と記事リストが正しく表示されること', () => {
+    render(<AuthorPage {...mockProps} />);
+
+    // レイアウトが表示されていることを確認
+    expect(screen.getByTestId('mock-layout')).toBeInTheDocument();
+
+    // 著者プロフィールが表示されていることを確認
+    expect(screen.getByTestId('mock-user-profile')).toBeInTheDocument();
+    expect(screen.getByText('テスト著者')).toBeInTheDocument();
+    expect(screen.getByText('テスト著者の記事一覧')).toBeInTheDocument();
+
+    // タブナビゲーションが表示されていることを確認
+    expect(screen.getByTestId('mock-tab-navigation')).toBeInTheDocument();
+    expect(screen.getByText('すべての記事')).toBeInTheDocument();
+
+    // 記事リストが表示されていることを確認
+    expect(screen.getByTestId('mock-article-list')).toBeInTheDocument();
+    expect(screen.getByText('記事数: 2')).toBeInTheDocument();
+    expect(screen.getByText('テスト記事1')).toBeInTheDocument();
+    expect(screen.getByText('テスト記事2')).toBeInTheDocument();
+  });
+
+  it('記事がない場合も正しく表示されること', () => {
+    const propsWithoutPosts = {
+      ...mockProps,
+      posts: [],
+    };
+
+    render(<AuthorPage {...propsWithoutPosts} />);
+
+    // 記事数が0であることを確認
+    expect(screen.getByText('記事数: 0')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/pages/authors.test.tsx
+++ b/src/__tests__/pages/authors.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import AuthorsPage from '@/pages/authors';
+
+// モックコンポーネント
+jest.mock('@/components/layout/BaseLayout', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <div data-testid="mock-layout">{children}</div>,
+}));
+
+jest.mock('@/components/common/Heading', () => ({
+  __esModule: true,
+  default: ({ children, level }: { children: React.ReactNode; level: number; className?: string }) => (
+    <div data-testid={`mock-heading-${level}`}>{children}</div>
+  ),
+}));
+
+jest.mock('@/components/common/Link', () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: React.ReactNode; href: string; className?: string }) => (
+    <a data-testid="mock-link" href={href}>
+      {children}
+    </a>
+  ),
+}));
+
+describe('AuthorsPage', () => {
+  it('著者一覧が正しく表示されること', () => {
+    const mockProps = {
+      authors: [
+        { id: 'author-one', name: 'Author One', postCount: 3 },
+        { id: 'author-two', name: 'Author Two', postCount: 2 },
+        { id: 'author-three', name: 'Author Three', postCount: 1 },
+      ],
+    };
+
+    render(<AuthorsPage {...mockProps} />);
+
+    // レイアウトが表示されていることを確認
+    expect(screen.getByTestId('mock-layout')).toBeInTheDocument();
+
+    // 見出しが表示されていることを確認
+    expect(screen.getByTestId('mock-heading-1')).toBeInTheDocument();
+    expect(screen.getByText('著者一覧')).toBeInTheDocument();
+
+    // 著者カードが表示されていることを確認
+    expect(screen.getAllByTestId('mock-heading-2')).toHaveLength(3);
+    expect(screen.getByText('Author One')).toBeInTheDocument();
+    expect(screen.getByText('Author Two')).toBeInTheDocument();
+    expect(screen.getByText('Author Three')).toBeInTheDocument();
+
+    // 記事数が表示されていることを確認
+    expect(screen.getByText('記事数: 3')).toBeInTheDocument();
+    expect(screen.getByText('記事数: 2')).toBeInTheDocument();
+    expect(screen.getByText('記事数: 1')).toBeInTheDocument();
+
+    // リンクが正しいhref属性を持っていることを確認
+    const links = screen.getAllByTestId('mock-link');
+    expect(links[0]).toHaveAttribute('href', '/author/author-one');
+    expect(links[1]).toHaveAttribute('href', '/author/author-two');
+    expect(links[2]).toHaveAttribute('href', '/author/author-three');
+  });
+
+  it('著者が存在しない場合のメッセージが表示されること', () => {
+    const mockProps = {
+      authors: [],
+    };
+
+    render(<AuthorsPage {...mockProps} />);
+
+    // 著者が見つからないメッセージが表示されることを確認
+    expect(screen.getByText('著者が見つかりません。')).toBeInTheDocument();
+  });
+});

--- a/src/components/features/Article/ArticleCard.tsx
+++ b/src/components/features/Article/ArticleCard.tsx
@@ -3,25 +3,36 @@ import Link from '@/components/common/Link';
 import Heading from '@/components/common/Heading';
 import Paragraph from '@/components/common/Paragraph';
 import TagBadge from '@/components/common/TagBadge';
+import { PostData } from '@/lib/posts';
 
-// posts.ts から Omit<PostData, 'contentHtml'> をインポートしたいが、一旦定義
-// TODO: src/types/index.ts などで共通化を検討
-type ArticleCardProps = {
-  id: string;
-  title: string;
-  date: string;
-  tags?: string[];
-};
+// posts.ts から型をインポート
+type ArticleCardProps = Omit<PostData, 'contentHtml'>;
 
-export const ArticleCard: React.FC<ArticleCardProps> = ({ id, title, date, tags }) => {
+export const ArticleCard: React.FC<ArticleCardProps> = ({ id, title, date, tags, author }) => {
+  // 著者IDを作成（小文字にしてスペースをハイフンに置換）
+  const authorId = author ? encodeURIComponent(author.toLowerCase().replace(/\s+/g, '-')) : null;
+
   return (
     <article className="border border-neutral-200 rounded-lg p-6 hover:shadow-md transition-shadow duration-200">
       <Heading level={2} className="text-xl mb-2 border-none pb-0">
         <Link href={`/posts/${id}`}>{title}</Link>
       </Heading>
-      <Paragraph className="text-sm text-neutral-500 mb-4">
-        <time dateTime={date}>{date}</time>
-      </Paragraph>
+      
+      <div className="flex flex-wrap items-center text-sm text-neutral-500 mb-4">
+        <time dateTime={date} className="mr-4">
+          {date}
+        </time>
+        
+        {author && authorId && (
+          <span>
+            <span className="mr-1">by</span>
+            <Link href={`/author/${authorId}`} className="font-medium hover:text-neutral-800">
+              {author}
+            </Link>
+          </span>
+        )}
+      </div>
+      
       {tags && tags.length > 0 && (
         <div className="mt-2">
           {tags.map((tag) => (

--- a/src/components/features/Article/ArticleList.tsx
+++ b/src/components/features/Article/ArticleList.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import ArticleCard from './ArticleCard';
+import { PostData } from '@/lib/posts';
+
+type Article = Omit<PostData, 'contentHtml'>;
+
+type ArticleListProps = {
+  articles: Article[];
+  className?: string;
+};
+
+export const ArticleList: React.FC<ArticleListProps> = ({ articles, className = '' }) => {
+  if (articles.length === 0) {
+    return <div className={`text-center p-6 ${className}`}>記事がありません。</div>;
+  }
+
+  return (
+    <div className={className}>
+      <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+        {articles.map((article: Article) => (
+          <ArticleCard
+            key={article.id}
+            id={article.id}
+            title={article.title}
+            date={article.date}
+            tags={article.tags}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ArticleList; 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -10,11 +10,33 @@ export const Header: React.FC<HeaderProps> = ({ siteTitle = 'My Blog' }) => {
   return (
     <header className="border-b border-neutral-200 py-6">
       <div className="container mx-auto px-4">
-        <Heading level={1} className="text-xl font-semibold mb-0">
-          <Link href="/" className="text-neutral-800 hover:text-neutral-600 no-underline hover:no-underline">
-            {siteTitle}
-          </Link>
-        </Heading>
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between">
+          <Heading level={1} className="text-xl font-semibold mb-4 md:mb-0">
+            <Link href="/" className="text-neutral-800 hover:text-neutral-600 no-underline hover:no-underline">
+              {siteTitle}
+            </Link>
+          </Heading>
+          
+          <nav>
+            <ul className="flex space-x-6">
+              <li>
+                <Link href="/" className="text-neutral-600 hover:text-neutral-800">
+                  ホーム
+                </Link>
+              </li>
+              <li>
+                <Link href="/authors" className="text-neutral-600 hover:text-neutral-800">
+                  著者一覧
+                </Link>
+              </li>
+              <li>
+                <Link href="/tags" className="text-neutral-600 hover:text-neutral-800">
+                  タグ
+                </Link>
+              </li>
+            </ul>
+          </nav>
+        </div>
       </div>
     </header>
   );

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -50,7 +50,7 @@ export function getSortedPostsData(): Result<Omit<PostData, 'contentHtml'>[], Po
           title: matterResult.data.title,
           date: dateString, // 文字列に変換した日付を使用
           tags: matterResult.data.tags || [],
-          author: matterResult.data.author || undefined
+          author: matterResult.data.author || undefined,
         });
       } catch (e) {
         // ファイル読み込みやパースのエラー
@@ -125,7 +125,7 @@ export async function getPostData(id: string): Promise<Result<PostData, PostsErr
           title: matterResult.data.title,
           date: matterResult.data.date,
           tags: matterResult.data.tags || [],
-          author: matterResult.data.author || undefined
+          author: matterResult.data.author || undefined,
         });
       } catch (e) {
         return err({ type: 'MarkdownParseError', path: fullPath, error: e });
@@ -147,25 +147,25 @@ export async function getPostData(id: string): Promise<Result<PostData, PostsErr
 // 全著者のIDリストを取得
 export function getAllAuthorIds(): Result<{ params: { authorId: string } }[], PostsError> {
   const postsResult = getSortedPostsData();
-  
+
   if (postsResult.isErr()) {
     return err(postsResult.error);
   }
-  
+
   const posts = postsResult.value;
-  
+
   // 著者情報がある記事から著者を抽出し、重複を除去
   const authors = Array.from(
     new Set(
       posts
-        .filter(post => post.author) // author が存在する記事だけ抽出
-        .map(post => post.author!)
+        .filter((post) => post.author) // author が存在する記事だけ抽出
+        .map((post) => post.author as string) // 型アサーションを使用（filterですでにnullでないことを確認済み）
     )
   );
-  
+
   // 著者IDのパラメータオブジェクトを作成
   return ok(
-    authors.map(author => ({
+    authors.map((author) => ({
       params: {
         authorId: encodeURIComponent(author.toLowerCase().replace(/\s+/g, '-')),
       },
@@ -184,18 +184,18 @@ export function getAuthorNameFromId(authorId: string): string {
 // 著者別の記事を取得
 export function getPostsByAuthor(authorId: string): Result<Omit<PostData, 'contentHtml'>[], PostsError> {
   const postsResult = getSortedPostsData();
-  
+
   if (postsResult.isErr()) {
     return err(postsResult.error);
   }
-  
+
   const posts = postsResult.value;
   const authorName = getAuthorNameFromId(authorId);
-  
+
   // 著者名が一致する記事だけをフィルタリング
-  const authorPosts = posts.filter(post => {
+  const authorPosts = posts.filter((post) => {
     return post.author && post.author.toLowerCase() === authorName.toLowerCase();
   });
-  
+
   return ok(authorPosts);
 }

--- a/src/pages/author/[authorId].tsx
+++ b/src/pages/author/[authorId].tsx
@@ -1,0 +1,86 @@
+import { GetStaticProps, GetStaticPaths } from 'next';
+import { ParsedUrlQuery } from 'querystring'
+import React from 'react';
+import BaseLayout from '@/components/layout/BaseLayout'
+import UserProfileHeader from '@/components/features/UserProfile/UserProfileHeader'
+import TabNavigation from '@/components/features/Navigation/TabNavigation'
+import ArticleList from '@/components/features/Article/ArticleList'
+import { getAllAuthorIds, getAuthorNameFromId, getPostsByAuthor, PostData } from '@/lib/posts';
+
+interface AuthorParams extends ParsedUrlQuery {
+  authorId: string;
+}
+
+type AuthorPageProps = {
+  authorName: string;
+  posts: Omit<PostData, 'contentHtml'>[];
+  authorId: string;
+};
+
+export default function AuthorPage({ authorName, posts, authorId }: AuthorPageProps) {
+  // タブナビゲーション用のタブ定義
+  const tabs = [
+    { label: 'すべての記事', href: `/author/${authorId}` },
+    // 将来的に「人気の記事」や「最新の記事」など他のタブを追加できる
+  ];
+
+  return (
+    <BaseLayout>
+      <div className="container mx-auto px-4 py-8">
+        <UserProfileHeader userName={authorName} description={`${authorName}の記事一覧`} />
+        
+        <TabNavigation tabs={tabs} activeHref={`/author/${authorId}`} />
+        
+        <ArticleList articles={posts} />
+      </div>
+    </BaseLayout>
+  );
+}
+
+// 動的ルーティングのためのパスを生成
+export const getStaticPaths: GetStaticPaths<AuthorParams> = async () => {
+  const authorIdsResult = getAllAuthorIds();
+  
+  if (authorIdsResult.isErr()) {
+    console.error('Error fetching author IDs:', authorIdsResult.error);
+    return {
+      paths: [],
+      fallback: false,
+    };
+  }
+  
+  return {
+    paths: authorIdsResult.value,
+    fallback: false, // 存在しないパスは404に
+  };
+};
+
+// 各著者ページのデータを取得
+export const getStaticProps: GetStaticProps<AuthorPageProps, AuthorParams> = async ({ params }) => {
+  if (!params) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const { authorId } = params;
+  const authorName = getAuthorNameFromId(authorId);
+  const postsResult = getPostsByAuthor(authorId);
+  
+  if (postsResult.isErr()) {
+    console.error(`Error fetching posts for author ${authorId}:`, postsResult.error);
+    return {
+      notFound: true,
+    };
+  }
+  
+  const posts = postsResult.value;
+  
+  return {
+    props: {
+      authorName,
+      posts,
+      authorId,
+    },
+  };
+}; 

--- a/src/pages/authors.tsx
+++ b/src/pages/authors.tsx
@@ -19,24 +19,25 @@ export default function AuthorsPage({ authors }: AuthorsPageProps) {
   return (
     <BaseLayout>
       <div className="container mx-auto px-4 py-8">
-        <Heading level={1} className="mb-8">著者一覧</Heading>
-        
+        <Heading level={1} className="mb-8">
+          著者一覧
+        </Heading>
+
         <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
           {authors.map((author) => (
-            <div key={author.id} className="border border-neutral-200 rounded-lg p-6 hover:shadow-md transition-shadow duration-200">
+            <div
+              key={author.id}
+              className="border border-neutral-200 rounded-lg p-6 hover:shadow-md transition-shadow duration-200"
+            >
               <Heading level={2} className="text-xl mb-2 border-none pb-0">
                 <Link href={`/author/${author.id}`}>{author.name}</Link>
               </Heading>
-              <p className="text-sm text-neutral-500">
-                記事数: {author.postCount}
-              </p>
+              <p className="text-sm text-neutral-500">記事数: {author.postCount}</p>
             </div>
           ))}
         </div>
-        
-        {authors.length === 0 && (
-          <p className="text-center p-6">著者が見つかりません。</p>
-        )}
+
+        {authors.length === 0 && <p className="text-center p-6">著者が見つかりません。</p>}
       </div>
     </BaseLayout>
   );
@@ -45,7 +46,7 @@ export default function AuthorsPage({ authors }: AuthorsPageProps) {
 export const getStaticProps: GetStaticProps<AuthorsPageProps> = async () => {
   // 全著者IDを取得
   const authorIdsResult = getAllAuthorIds();
-  
+
   if (authorIdsResult.isErr()) {
     console.error('Error fetching author IDs:', authorIdsResult.error);
     return {
@@ -54,10 +55,10 @@ export const getStaticProps: GetStaticProps<AuthorsPageProps> = async () => {
       },
     };
   }
-  
+
   // 記事一覧を取得
   const postsResult = getSortedPostsData();
-  
+
   if (postsResult.isErr()) {
     console.error('Error fetching posts:', postsResult.error);
     return {
@@ -66,34 +67,35 @@ export const getStaticProps: GetStaticProps<AuthorsPageProps> = async () => {
       },
     };
   }
-  
+
   const posts = postsResult.value;
-  
+
   // 著者ごとの記事数をカウント
   const authorCounts: Record<string, number> = {};
   const authorNames: Record<string, string> = {};
-  
-  posts.forEach((post) => {
+
+  // for...ofループを使用
+  for (const post of posts) {
     if (post.author) {
       const authorId = post.author.toLowerCase().replace(/\s+/g, '-');
       authorCounts[authorId] = (authorCounts[authorId] || 0) + 1;
       authorNames[authorId] = post.author;
     }
-  });
-  
+  }
+
   // 著者情報の配列を作成
   const authors: AuthorInfo[] = Object.keys(authorCounts).map((authorId) => ({
     id: authorId,
     name: authorNames[authorId],
     postCount: authorCounts[authorId],
   }));
-  
+
   // 記事数の多い順にソート
   authors.sort((a, b) => b.postCount - a.postCount);
-  
+
   return {
     props: {
       authors,
     },
   };
-}; 
+};

--- a/src/pages/authors.tsx
+++ b/src/pages/authors.tsx
@@ -1,0 +1,99 @@
+import { GetStaticProps } from 'next';
+import React from 'react';
+import Link from '@/components/common/Link';
+import BaseLayout from '@/components/layout/BaseLayout';
+import Heading from '@/components/common/Heading';
+import { getAllAuthorIds, getSortedPostsData, PostData } from '@/lib/posts';
+
+type AuthorInfo = {
+  name: string;
+  id: string;
+  postCount: number;
+};
+
+type AuthorsPageProps = {
+  authors: AuthorInfo[];
+};
+
+export default function AuthorsPage({ authors }: AuthorsPageProps) {
+  return (
+    <BaseLayout>
+      <div className="container mx-auto px-4 py-8">
+        <Heading level={1} className="mb-8">著者一覧</Heading>
+        
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {authors.map((author) => (
+            <div key={author.id} className="border border-neutral-200 rounded-lg p-6 hover:shadow-md transition-shadow duration-200">
+              <Heading level={2} className="text-xl mb-2 border-none pb-0">
+                <Link href={`/author/${author.id}`}>{author.name}</Link>
+              </Heading>
+              <p className="text-sm text-neutral-500">
+                記事数: {author.postCount}
+              </p>
+            </div>
+          ))}
+        </div>
+        
+        {authors.length === 0 && (
+          <p className="text-center p-6">著者が見つかりません。</p>
+        )}
+      </div>
+    </BaseLayout>
+  );
+}
+
+export const getStaticProps: GetStaticProps<AuthorsPageProps> = async () => {
+  // 全著者IDを取得
+  const authorIdsResult = getAllAuthorIds();
+  
+  if (authorIdsResult.isErr()) {
+    console.error('Error fetching author IDs:', authorIdsResult.error);
+    return {
+      props: {
+        authors: [],
+      },
+    };
+  }
+  
+  // 記事一覧を取得
+  const postsResult = getSortedPostsData();
+  
+  if (postsResult.isErr()) {
+    console.error('Error fetching posts:', postsResult.error);
+    return {
+      props: {
+        authors: [],
+      },
+    };
+  }
+  
+  const posts = postsResult.value;
+  
+  // 著者ごとの記事数をカウント
+  const authorCounts: Record<string, number> = {};
+  const authorNames: Record<string, string> = {};
+  
+  posts.forEach((post) => {
+    if (post.author) {
+      const authorId = post.author.toLowerCase().replace(/\s+/g, '-');
+      authorCounts[authorId] = (authorCounts[authorId] || 0) + 1;
+      authorNames[authorId] = post.author;
+    }
+  });
+  
+  // 著者情報の配列を作成
+  const authors: AuthorInfo[] = Object.keys(authorCounts).map((authorId) => ({
+    id: authorId,
+    name: authorNames[authorId],
+    postCount: authorCounts[authorId],
+  }));
+  
+  // 記事数の多い順にソート
+  authors.sort((a, b) => b.postCount - a.postCount);
+  
+  return {
+    props: {
+      authors,
+    },
+  };
+}; 


### PR DESCRIPTION
## 概要\nIssue #38 の実装として、著者別記事一覧ページを新規作成しました。\n\n## 変更内容\n- 著者別記事一覧ページ（src/pages/author/[authorId].tsx）の作成\n- 著者一覧ページ（src/pages/authors.tsx）の作成\n- 記事カードに著者情報とリンクを追加\n- ヘッダーナビゲーションに著者一覧へのリンクを追加\n- postsライブラリに著者関連の機能を追加\n- 単体テストとコンポーネントテストの追加\n\n## テスト手順\n1. npm test でテストが通ることを確認\n2. 著者リンクをクリックして著者ページに移動できることを確認\n3. ヘッダーナビゲーションから著者一覧ページに移動できることを確認\n\nCloses #38