### PR TITLE
feat: 記事詳細ページの改修

### DIFF
--- a/src/__tests__/pages/post.test.tsx
+++ b/src/__tests__/pages/post.test.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import Post from '@/pages/posts/[id]';
+import { PostData } from '@/lib/posts';
+
+// モックコンポーネント
+jest.mock('@/components/layout/BaseLayout', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <div data-testid="mock-layout">{children}</div>,
+}));
+
+jest.mock('@/components/features/Article/ArticleHeader', () => ({
+  __esModule: true,
+  default: ({
+    title,
+    publishedDate,
+    authorName,
+    authorLink,
+  }: { title: string; publishedDate: string; authorName: string; authorLink: string }) => (
+    <div data-testid="mock-article-header">
+      <h1>{title}</h1>
+      <p>{publishedDate}</p>
+      <a href={authorLink}>{authorName}</a>
+    </div>
+  ),
+}));
+
+jest.mock('@/components/features/Article/ArticleBody', () => ({
+  __esModule: true,
+  default: ({ markdownContent }: { markdownContent: string }) => (
+    // biome-ignore lint/security/noDangerouslySetInnerHtml: <Test mock>
+    <div data-testid="mock-article-body" dangerouslySetInnerHTML={{ __html: markdownContent }} />
+  ),
+}));
+
+jest.mock('@/components/features/Article/AuthorProfile', () => ({
+  __esModule: true,
+  default: ({ authorName, authorLink }: { authorName: string; authorLink: string }) => (
+    <div data-testid="mock-author-profile">
+      <a href={authorLink}>{authorName}</a>
+    </div>
+  ),
+}));
+
+describe('Post Page', () => {
+  const mockPost: PostData = {
+    id: 'test-post',
+    title: 'テスト投稿のタイトル',
+    date: '2024-05-06',
+    tags: ['React', 'Next.js'],
+    author: 'テスト太郎',
+    contentHtml: '<p>これは<strong>テスト用</strong>のHTMLコンテンツです。</p>',
+  };
+
+  const mockPostWithoutAuthor: PostData = {
+    id: 'test-post-no-author',
+    title: '著者なしテスト投稿',
+    date: '2024-05-05',
+    tags: ['Test'],
+    contentHtml: '<p>著者情報がないテスト。</p>',
+  };
+
+  it('記事のヘッダー、本文、著者プロフィールが正しく表示されること', () => {
+    render(<Post post={mockPost} />);
+
+    // レイアウトがあるか
+    expect(screen.getByTestId('mock-layout')).toBeInTheDocument();
+
+    // ヘッダーがあるか
+    const header = screen.getByTestId('mock-article-header');
+    expect(header).toBeInTheDocument();
+    expect(within(header).getByText(mockPost.title)).toBeInTheDocument();
+    expect(within(header).getByText(mockPost.date)).toBeInTheDocument();
+    if (mockPost.author) {
+      const expectedAuthorId = encodeURIComponent(mockPost.author.toLowerCase().replace(/\s+/g, '-'));
+      const authorLinkInHeader = within(header).getByText(mockPost.author).closest('a');
+      expect(authorLinkInHeader).toBeInTheDocument();
+      expect(authorLinkInHeader).toHaveAttribute('href', `/author/${expectedAuthorId}`);
+    }
+
+    // 本文があるか
+    expect(screen.getByTestId('mock-article-body')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-article-body').innerHTML).toBe(mockPost.contentHtml);
+
+    // 著者プロフィールがあるか
+    const authorProfile = screen.getByTestId('mock-author-profile');
+    expect(authorProfile).toBeInTheDocument();
+    if (mockPost.author) {
+      const expectedAuthorId = encodeURIComponent(mockPost.author.toLowerCase().replace(/\s+/g, '-'));
+      const authorLinkInProfile = within(authorProfile).getByText(mockPost.author).closest('a');
+      expect(authorLinkInProfile).toBeInTheDocument();
+      expect(authorLinkInProfile).toHaveAttribute('href', `/author/${expectedAuthorId}`);
+    }
+  });
+
+  it('著者がいない場合、匿名で表示され、著者プロフィールは表示されないこと', () => {
+    render(<Post post={mockPostWithoutAuthor} />);
+
+    // ヘッダーで著者が「匿名」と表示されることを確認
+    const header = screen.getByTestId('mock-article-header');
+    expect(within(header).getByText('匿名')).toBeInTheDocument();
+    const authorLink = within(header).getByText('匿名').closest('a');
+    expect(authorLink).toHaveAttribute('href', '#');
+
+    // 本文があるか
+    expect(screen.getByTestId('mock-article-body')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-article-body').innerHTML).toBe(mockPostWithoutAuthor.contentHtml);
+
+    // 著者プロフィールが表示されないことを確認
+    expect(screen.queryByTestId('mock-author-profile')).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/posts/[id].tsx
+++ b/src/pages/posts/[id].tsx
@@ -1,34 +1,37 @@
 import type { GetStaticProps, GetStaticPaths, GetStaticPropsContext } from 'next';
-import Layout from '@/components/Layout';
+import BaseLayout from '@/components/layout/BaseLayout';
 import { getAllPostIds, getPostData } from '@/lib/posts';
 import type { PostData, PostsError } from '@/lib/posts';
+import ArticleHeader from '@/components/features/Article/ArticleHeader';
+import ArticleBody from '@/components/features/Article/ArticleBody';
+import AuthorProfile from '@/components/features/Article/AuthorProfile';
 
 type Props = {
   post: PostData;
 };
 
 export default function Post({ post }: Props) {
+  const authorId = post.author ? encodeURIComponent(post.author.toLowerCase().replace(/\s+/g, '-')) : null;
+
   return (
-    <Layout>
-      <article className="prose prose-lg mx-auto">
-        <h1 className="text-3xl font-bold mb-4">{post.title}</h1>
-        <div className="mb-8">
-          <div className="text-gray-500 mb-4">{post.date}</div>
-          <div className="flex gap-2">
-            {post.tags.map((tag) => (
-              <span key={tag} className="bg-gray-100 text-gray-700 px-2 py-1 rounded text-sm">
-                {tag}
-              </span>
-            ))}
-          </div>
-        </div>
-        <div
-          className="mt-8"
-          // biome-ignore lint/security/noDangerouslySetInnerHtml: <explanation>
-          dangerouslySetInnerHTML={{ __html: post.contentHtml }}
-        />
-      </article>
-    </Layout>
+    <BaseLayout>
+      <div className="container mx-auto px-4 py-12 max-w-3xl">
+        <article>
+          <ArticleHeader
+            title={post.title}
+            publishedDate={post.date}
+            authorName={post.author || '匿名'}
+            authorLink={authorId ? `/author/${authorId}` : '#'}
+          />
+          <ArticleBody markdownContent={post.contentHtml} />
+          {post.author && authorId && (
+            <div className="mt-12 pt-8 border-t border-neutral-200">
+              <AuthorProfile authorName={post.author} authorLink={`/author/${authorId}`} />
+            </div>
+          )}
+        </article>
+      </div>
+    </BaseLayout>
   );
 }
 


### PR DESCRIPTION
## 概要
Issue #39 の実装として、記事詳細ページを「しずかなインターネット」風のデザインに改修しました。

## 変更内容
- `src/pages/posts/[id].tsx` を Issue #35 で作成したコンポーネント (`ArticleHeader`, `ArticleBody`, `AuthorProfile`) を使用するように修正。
- `BaseLayout` を使用するように変更。
- 記事詳細ページのテスト (`src/__tests__/pages/post.test.tsx`) を追加。
- 関連する Lint エラーとテストエラーを修正。

## テスト手順
1. `npm test` で全てのテストが通ることを確認。
2. 各記事ページ (`/posts/xxxx`) が正しく表示されることを確認。
3. 記事ヘッダー、本文、著者プロフィールが適切に表示されていることを確認。

Closes #39