### PR TITLE
feat: タグ別記事一覧ページの作成

### DIFF
--- a/src/__tests__/lib/posts.test.ts
+++ b/src/__tests__/lib/posts.test.ts
@@ -1,5 +1,12 @@
 import path from 'path';
-import { getAllAuthorIds, getAuthorNameFromId, getPostsByAuthor } from '@/lib/posts';
+import {
+  getAllAuthorIds,
+  getAuthorNameFromId,
+  getPostsByAuthor,
+  getAllTagsWithCount,
+  getAllTagIds,
+  getPostsByTag,
+} from '@/lib/posts';
 
 // モックファイルシステム
 jest.mock('node:fs', () => {
@@ -29,62 +36,134 @@ jest.mock('node:fs', () => {
 // jest.mockされたモジュールの型を解決するためのアサーション
 const fs = jest.requireMock('node:fs');
 
-describe('posts.ts - 著者関連機能', () => {
+describe('posts.ts', () => {
   beforeEach(() => {
     // モックのリセット
     jest.clearAllMocks();
   });
 
-  describe('getAllAuthorIds', () => {
-    it('すべての著者IDを取得できること', () => {
-      const result = getAllAuthorIds();
+  describe('著者関連機能', () => {
+    describe('getAllAuthorIds', () => {
+      it('すべての著者IDを取得できること', () => {
+        const result = getAllAuthorIds();
 
-      expect(result.isOk()).toBe(true);
-      if (result.isOk()) {
-        // 順序が重要でないため、配列の要素がすべて含まれているかをチェック
-        expect(result.value).toHaveLength(2);
-        expect(result.value).toEqual(
-          expect.arrayContaining([{ params: { authorId: 'author-one' } }, { params: { authorId: 'author-two' } }])
-        );
-      }
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+          // 順序が重要でないため、配列の要素がすべて含まれているかをチェック
+          expect(result.value).toHaveLength(2);
+          expect(result.value).toEqual(
+            expect.arrayContaining([{ params: { authorId: 'author-one' } }, { params: { authorId: 'author-two' } }])
+          );
+        }
 
-      // ファイル読み込みが呼ばれたことの確認
-      expect(fs.readdirSync).toHaveBeenCalled();
-      expect(fs.readFileSync).toHaveBeenCalled();
+        // ファイル読み込みが呼ばれたことの確認
+        expect(fs.readdirSync).toHaveBeenCalled();
+        expect(fs.readFileSync).toHaveBeenCalled();
+      });
+    });
+
+    describe('getAuthorNameFromId', () => {
+      it('著者IDから著者名を取得できること', () => {
+        const authorName = getAuthorNameFromId('author-one');
+        expect(authorName).toBe('author one');
+      });
+
+      it('空白を含む著者IDを正しく処理できること', () => {
+        const authorName = getAuthorNameFromId('author-with-multiple-words');
+        expect(authorName).toBe('author with multiple words');
+      });
+    });
+
+    describe('getPostsByAuthor', () => {
+      it('特定の著者の記事を取得できること', () => {
+        const result = getPostsByAuthor('author-one');
+
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+          expect(result.value).toHaveLength(1);
+          expect(result.value[0].title).toBe('Test Post Author 1');
+          expect(result.value[0].author).toBe('Author One');
+        }
+      });
+
+      it('存在しない著者の場合は空の配列を返すこと', () => {
+        const result = getPostsByAuthor('non-existent-author');
+
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+          expect(result.value).toHaveLength(0);
+        }
+      });
     });
   });
 
-  describe('getAuthorNameFromId', () => {
-    it('著者IDから著者名を取得できること', () => {
-      const authorName = getAuthorNameFromId('author-one');
-      expect(authorName).toBe('author one');
+  describe('タグ関連機能', () => {
+    describe('getAllTagsWithCount', () => {
+      it('すべてのタグとその記事数を取得できること', () => {
+        const result = getAllTagsWithCount();
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+          expect(result.value).toEqual({
+            test: 2,
+            author1: 1,
+            author2: 1,
+          });
+        }
+      });
     });
 
-    it('空白を含む著者IDを正しく処理できること', () => {
-      const authorName = getAuthorNameFromId('author-with-multiple-words');
-      expect(authorName).toBe('author with multiple words');
+    describe('getAllTagIds', () => {
+      it('すべてのタグIDを取得できること (URLエンコード済み)', () => {
+        const result = getAllTagIds();
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+          expect(result.value).toHaveLength(3);
+          expect(result.value).toEqual(
+            expect.arrayContaining([
+              { params: { tag: 'test' } },
+              { params: { tag: 'author1' } },
+              { params: { tag: 'author2' } },
+            ])
+          );
+        }
+      });
     });
-  });
 
-  describe('getPostsByAuthor', () => {
-    it('特定の著者の記事を取得できること', () => {
-      const result = getPostsByAuthor('author-one');
+    describe('getPostsByTag', () => {
+      it('特定のタグを持つ記事を取得できること', () => {
+        const result = getPostsByTag('test'); // URLエンコードされていないタグで検索
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+          expect(result.value).toHaveLength(2);
+          expect(result.value.some((p) => p.id === 'test-author1')).toBe(true);
+          expect(result.value.some((p) => p.id === 'test-author2')).toBe(true);
+        }
+      });
 
-      expect(result.isOk()).toBe(true);
-      if (result.isOk()) {
-        expect(result.value).toHaveLength(1);
-        expect(result.value[0].title).toBe('Test Post Author 1');
-        expect(result.value[0].author).toBe('Author One');
-      }
-    });
+      it('URLエンコードされたタグ名でも記事を取得できること', () => {
+        const result = getPostsByTag(encodeURIComponent('test')); // URLエンコードされたタグで検索
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+          expect(result.value).toHaveLength(2);
+        }
+      });
 
-    it('存在しない著者の場合は空の配列を返すこと', () => {
-      const result = getPostsByAuthor('non-existent-author');
+      it('特定のタグのみを持つ記事を取得できること', () => {
+        const result = getPostsByTag('author1');
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+          expect(result.value).toHaveLength(1);
+          expect(result.value[0].id).toBe('test-author1');
+        }
+      });
 
-      expect(result.isOk()).toBe(true);
-      if (result.isOk()) {
-        expect(result.value).toHaveLength(0);
-      }
+      it('存在しないタグの場合は空の配列を返すこと', () => {
+        const result = getPostsByTag('non-existent-tag');
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+          expect(result.value).toHaveLength(0);
+        }
+      });
     });
   });
 });

--- a/src/__tests__/pages/tag.test.tsx
+++ b/src/__tests__/pages/tag.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import TagPage from '@/pages/tags/[tag]';
+import { PostData } from '@/lib/posts';
+
+// モックコンポーネント
+jest.mock('@/components/layout/BaseLayout', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <div data-testid="mock-layout">{children}</div>,
+}));
+
+jest.mock('@/components/common/Heading', () => ({
+  __esModule: true,
+  default: ({ children, level }: { children: React.ReactNode; level: number; className?: string }) => (
+    <div data-testid={`mock-heading-${level}`}>{children}</div>
+  ),
+}));
+
+jest.mock('@/components/features/Article/ArticleList', () => ({
+  __esModule: true,
+  default: ({ articles }: { articles: Omit<PostData, 'contentHtml'>[] }) => (
+    <div data-testid="mock-article-list">
+      <span>記事数: {articles.length}</span>
+      <ul>
+        {articles.map((article) => (
+          <li key={article.id}>{article.title}</li>
+        ))}
+      </ul>
+    </div>
+  ),
+}));
+
+describe('TagPage', () => {
+  const mockProps = {
+    tag: 'test', // URLエンコードされていない想定
+    posts: [
+      {
+        id: 'test-post-1',
+        title: 'テスト記事1',
+        date: '2024-01-01',
+        tags: ['test', 'React'],
+        author: '著者1',
+      },
+      {
+        id: 'test-post-2',
+        title: 'テスト記事2',
+        date: '2024-01-02',
+        tags: ['test', 'Next.js'],
+        author: '著者2',
+      },
+    ],
+  };
+
+  const mockPropsEncodedTag = {
+    tag: encodeURIComponent('Next.js'), // URLエンコードされたタグ
+    posts: [
+      {
+        id: 'test-post-2',
+        title: 'テスト記事2',
+        date: '2024-01-02',
+        tags: ['test', 'Next.js'],
+        author: '著者2',
+      },
+    ],
+  };
+
+  it('タグ名と記事リストが正しく表示されること', () => {
+    render(<TagPage {...mockProps} />);
+
+    // レイアウトが表示されていることを確認
+    expect(screen.getByTestId('mock-layout')).toBeInTheDocument();
+
+    // 見出しが表示されていることを確認
+    expect(screen.getByTestId('mock-heading-1')).toBeInTheDocument();
+    expect(screen.getByText(`タグ: ${mockProps.tag}`)).toBeInTheDocument();
+
+    // 記事リストが表示されていることを確認
+    expect(screen.getByTestId('mock-article-list')).toBeInTheDocument();
+    expect(screen.getByText('記事数: 2')).toBeInTheDocument();
+    expect(screen.getByText('テスト記事1')).toBeInTheDocument();
+    expect(screen.getByText('テスト記事2')).toBeInTheDocument();
+  });
+
+  it('URLエンコードされたタグ名でも正しく表示されること', () => {
+    render(<TagPage {...mockPropsEncodedTag} />);
+
+    // 見出しにデコードされたタグ名が表示されること
+    expect(screen.getByText(`タグ: Next.js`)).toBeInTheDocument();
+
+    // 記事リストが表示されていることを確認
+    expect(screen.getByText('記事数: 1')).toBeInTheDocument();
+    expect(screen.getByText('テスト記事2')).toBeInTheDocument();
+  });
+
+  it('記事がない場合も正しく表示されること', () => {
+    const propsWithoutPosts = {
+      ...mockProps,
+      posts: [],
+    };
+    render(<TagPage {...propsWithoutPosts} />);
+    expect(screen.getByText('記事数: 0')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/pages/tags.test.tsx
+++ b/src/__tests__/pages/tags.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import TagsPage from '@/pages/tags';
+
+// モックコンポーネント
+jest.mock('@/components/layout/BaseLayout', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <div data-testid="mock-layout">{children}</div>,
+}));
+
+jest.mock('@/components/common/Heading', () => ({
+  __esModule: true,
+  default: ({ children, level }: { children: React.ReactNode; level: number; className?: string }) => (
+    <div data-testid={`mock-heading-${level}`}>{children}</div>
+  ),
+}));
+
+jest.mock('@/components/common/Link', () => ({
+  __esModule: true,
+  default: ({ children, href, className }: { children: React.ReactNode; href: string; className?: string }) => (
+    <a data-testid="mock-tag-link" href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+describe('TagsPage', () => {
+  it('タグ一覧が正しく表示され、記事数が多い順にソートされていること', () => {
+    const mockProps = {
+      tags: [
+        { name: 'React', count: 5 },
+        { name: 'Next.js', count: 3 },
+        { name: 'TypeScript', count: 2 },
+      ],
+    };
+
+    render(<TagsPage {...mockProps} />);
+
+    // レイアウトが表示されていることを確認
+    expect(screen.getByTestId('mock-layout')).toBeInTheDocument();
+
+    // 見出しが表示されていることを確認
+    expect(screen.getByTestId('mock-heading-1')).toBeInTheDocument();
+    expect(screen.getByText('タグ一覧')).toBeInTheDocument();
+
+    // タグリンクが表示されていることを確認
+    const tagLinks = screen.getAllByTestId('mock-tag-link');
+    expect(tagLinks).toHaveLength(3);
+
+    // 表示順序（記事数順）を確認
+    expect(tagLinks[0]).toHaveTextContent('React(5)');
+    expect(tagLinks[1]).toHaveTextContent('Next.js(3)');
+    expect(tagLinks[2]).toHaveTextContent('TypeScript(2)');
+
+    // リンクのhref属性を確認
+    expect(tagLinks[0]).toHaveAttribute('href', '/tags/React');
+    expect(tagLinks[1]).toHaveAttribute('href', '/tags/Next.js');
+    expect(tagLinks[2]).toHaveAttribute('href', '/tags/TypeScript');
+  });
+
+  it('タグが存在しない場合のメッセージが表示されること', () => {
+    const mockProps = {
+      tags: [],
+    };
+
+    render(<TagsPage {...mockProps} />);
+
+    // タグが見つからないメッセージが表示されることを確認
+    expect(screen.getByText('タグが見つかりません。')).toBeInTheDocument();
+  });
+});

--- a/src/pages/tags.tsx
+++ b/src/pages/tags.tsx
@@ -1,0 +1,66 @@
+import { GetStaticProps } from 'next';
+import React from 'react';
+import Link from '@/components/common/Link';
+import BaseLayout from '@/components/layout/BaseLayout';
+import Heading from '@/components/common/Heading';
+import { getAllTagsWithCount } from '@/lib/posts';
+
+type TagInfo = {
+  name: string;
+  count: number;
+};
+
+type TagsPageProps = {
+  tags: TagInfo[];
+};
+
+export default function TagsPage({ tags }: TagsPageProps) {
+  return (
+    <BaseLayout>
+      <div className="container mx-auto px-4 py-8">
+        <Heading level={1} className="mb-8">
+          タグ一覧
+        </Heading>
+
+        <div className="flex flex-wrap gap-4">
+          {tags.map((tag) => (
+            <Link
+              key={tag.name}
+              href={`/tags/${encodeURIComponent(tag.name)}`}
+              className="block border border-neutral-200 rounded-lg px-4 py-2 hover:bg-neutral-50 transition-colors duration-150"
+            >
+              <span className="font-medium">{tag.name}</span>
+              <span className="ml-2 text-sm text-neutral-500">({tag.count})</span>
+            </Link>
+          ))}
+        </div>
+
+        {tags.length === 0 && <p className="text-center p-6">タグが見つかりません。</p>}
+      </div>
+    </BaseLayout>
+  );
+}
+
+export const getStaticProps: GetStaticProps<TagsPageProps> = async () => {
+  const tagsResult = getAllTagsWithCount();
+
+  if (tagsResult.isErr()) {
+    console.error('Error fetching tags:', tagsResult.error);
+    return {
+      props: {
+        tags: [],
+      },
+    };
+  }
+
+  const tagCounts = tagsResult.value;
+  const tags: TagInfo[] = Object.entries(tagCounts)
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count); // 記事数の多い順にソート
+
+  return {
+    props: {
+      tags,
+    },
+  };
+};

--- a/src/pages/tags/[tag].tsx
+++ b/src/pages/tags/[tag].tsx
@@ -1,0 +1,78 @@
+import { GetStaticProps, GetStaticPaths } from 'next';
+import { ParsedUrlQuery } from 'querystring';
+import React from 'react';
+import BaseLayout from '@/components/layout/BaseLayout';
+import ArticleList from '@/components/features/Article/ArticleList';
+import Heading from '@/components/common/Heading';
+import { getAllTagIds, getPostsByTag, PostData } from '@/lib/posts';
+
+interface TagParams extends ParsedUrlQuery {
+  tag: string;
+}
+
+type TagPageProps = {
+  tag: string;
+  posts: Omit<PostData, 'contentHtml'>[];
+};
+
+export default function TagPage({ tag, posts }: TagPageProps) {
+  const decodedTag = decodeURIComponent(tag);
+
+  return (
+    <BaseLayout>
+      <div className="container mx-auto px-4 py-8">
+        <Heading level={1} className="mb-8">
+          タグ: {decodedTag}
+        </Heading>
+
+        <ArticleList articles={posts} />
+      </div>
+    </BaseLayout>
+  );
+}
+
+// 動的ルーティングのためのパスを生成
+export const getStaticPaths: GetStaticPaths<TagParams> = async () => {
+  const tagIdsResult = getAllTagIds();
+
+  if (tagIdsResult.isErr()) {
+    console.error('Error fetching tag IDs:', tagIdsResult.error);
+    return {
+      paths: [],
+      fallback: false,
+    };
+  }
+
+  return {
+    paths: tagIdsResult.value,
+    fallback: false, // 存在しないパスは404に
+  };
+};
+
+// 各タグページのデータを取得
+export const getStaticProps: GetStaticProps<TagPageProps, TagParams> = async ({ params }) => {
+  if (!params) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const { tag } = params;
+  const postsResult = getPostsByTag(tag);
+
+  if (postsResult.isErr()) {
+    console.error(`Error fetching posts for tag ${tag}:`, postsResult.error);
+    return {
+      notFound: true,
+    };
+  }
+
+  const posts = postsResult.value;
+
+  return {
+    props: {
+      tag, // URLエンコードされたままのタグを渡す
+      posts,
+    },
+  };
+};


### PR DESCRIPTION
## 概要
Issue #40 の実装として、タグ別記事一覧ページとタグ一覧ページを作成しました。

## 変更内容
- タグ別記事一覧ページ (`src/pages/tags/[tag].tsx`) を作成。
- タグ一覧ページ (`src/pages/tags.tsx`) を作成。
- `src/lib/posts.ts` にタグ関連の関数 (`getAllTagsWithCount`, `getAllTagIds`, `getPostsByTag`) を追加。
- 上記のページと関数に対応するテストを追加。

## テスト手順
1. `npm test` で全てのテストが通ることを確認。
2. `/tags` にアクセスしてタグ一覧が表示されることを確認。
3. タグ一覧から各タグをクリックして、対応するタグ別記事一覧ページ (`/tags/xxx`) が表示されることを確認。

Closes #40