### PR TITLE
Feat(style): フォントファミリーを指定スタックに変更 (Issue #53)

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,3 +1,11 @@
+@import url('https://fonts.googleapis.com/css2?family=BIZ+UDPGothic:wght@400;700&family=Inter:wght@400..700&family=Noto+Sans+JP:wght@400;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  body {
+    @apply font-sans;
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,17 @@ module.exports = {
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
+    fontFamily: {
+      sans: [
+        'Inter',
+        'Noto Sans JP',
+        'BIZ UDPGothic',
+        '"Hiragino Kaku Gothic ProN"',
+        '"Hiragino Sans"',
+        'Meiryo',
+        'sans-serif',
+      ],
+    },
     extend: {
       colors: {
         main: {


### PR DESCRIPTION
## 概要
Issue #53 の対応として、ブログ全体の基本フォントを指定されたフォントスタックに変更しました。

**指定フォントスタック:** `Inter, Noto Sans JP (GenJyuuGothicL代替), BIZ UDPGothic, Hiragino Kaku Gothic ProN, Hiragino Sans, Meiryo, sans-serif`

## 変更内容
- `src/styles/globals.css` にて、Google Fontsから以下のフォントを `@import` で読み込むようにしました:
  - Inter (wght 400-700)
  - Noto Sans JP (wght 400, 700)
  - BIZ UDPGothic (wght 400, 700)
- `tailwind.config.js` の `theme.fontFamily.sans` を上記フォントスタックで上書きしました。
- `src/styles/globals.css` の `body` タグに `@apply font-sans` を適用し、デフォルトフォントとして設定しました。

## 確認ポイント
- ブラウザの開発者ツールで確認し、意図したフォント（Inter, Noto Sans JP, BIZ UDPGothic および各OSのフォールバックフォント）が適用されていること。
- 特に日本語表示において、`Noto Sans JP` や `BIZ UDPGothic`、またはOS標準の日本語フォントが適切に表示されていること。
- サイト全体の見た目が意図通りであること。

Closes #53