### PR TITLE
fix(test): Layoutコンポーネントのモック修正と関連テスト更新

### DIFF
--- a/src/__tests__/pages/author.test.tsx
+++ b/src/__tests__/pages/author.test.tsx
@@ -4,7 +4,7 @@ import AuthorPage from '@/pages/author/[authorId]';
 import { PostData } from '@/lib/posts';
 
 // モックコンポーネント
-jest.mock('@/components/layout/BaseLayout', () => ({
+jest.mock('@/components/layout/Layout', () => ({
   __esModule: true,
   default: ({ children }: { children: React.ReactNode }) => <div data-testid="mock-layout">{children}</div>,
 }));

--- a/src/__tests__/pages/authors.test.tsx
+++ b/src/__tests__/pages/authors.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import AuthorsPage from '@/pages/authors';
 
 // モックコンポーネント
-jest.mock('@/components/layout/BaseLayout', () => ({
+jest.mock('@/components/layout/Layout', () => ({
   __esModule: true,
   default: ({ children }: { children: React.ReactNode }) => <div data-testid="mock-layout">{children}</div>,
 }));

--- a/src/__tests__/pages/post.test.tsx
+++ b/src/__tests__/pages/post.test.tsx
@@ -4,7 +4,7 @@ import Post from '@/pages/posts/[id]';
 import { PostData } from '@/lib/posts';
 
 // モックコンポーネント
-jest.mock('@/components/layout/BaseLayout', () => ({
+jest.mock('@/components/layout/Layout', () => ({
   __esModule: true,
   default: ({ children }: { children: React.ReactNode }) => <div data-testid="mock-layout">{children}</div>,
 }));
@@ -27,7 +27,7 @@ jest.mock('@/components/features/Article/ArticleHeader', () => ({
 
 jest.mock('@/components/features/Article/ArticleBody', () => ({
   __esModule: true,
-  default: ({ markdownContent }: { markdownContent: string }) => (
+  ArticleBody: ({ markdownContent }: { markdownContent: string }) => (
     // biome-ignore lint/security/noDangerouslySetInnerHtml: <Test mock>
     <div data-testid="mock-article-body" dangerouslySetInnerHTML={{ __html: markdownContent }} />
   ),

--- a/src/__tests__/pages/tag.test.tsx
+++ b/src/__tests__/pages/tag.test.tsx
@@ -4,7 +4,7 @@ import TagPage from '@/pages/tags/[tag]';
 import { PostData } from '@/lib/posts';
 
 // モックコンポーネント
-jest.mock('@/components/layout/BaseLayout', () => ({
+jest.mock('@/components/layout/Layout', () => ({
   __esModule: true,
   default: ({ children }: { children: React.ReactNode }) => <div data-testid="mock-layout">{children}</div>,
 }));

--- a/src/__tests__/pages/tags.test.tsx
+++ b/src/__tests__/pages/tags.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import TagsPage from '@/pages/tags';
 
 // モックコンポーネント
-jest.mock('@/components/layout/BaseLayout', () => ({
+jest.mock('@/components/layout/Layout', () => ({
   __esModule: true,
   default: ({ children }: { children: React.ReactNode }) => <div data-testid="mock-layout">{children}</div>,
 }));

--- a/src/components/common/Link.tsx
+++ b/src/components/common/Link.tsx
@@ -8,6 +8,7 @@ type LinkProps = {
   // target?: '_blank' | '_self' | '_parent' | '_top'; // target属性を追加
   // rel?: string; // rel属性を追加
   isExternal?: boolean; // 外部リンクかどうかを判定するフラグ
+  'data-testid'?: string; // data-testid を明示的に追加するのだ
 };
 
 export const Link: React.FC<LinkProps> = ({
@@ -17,6 +18,7 @@ export const Link: React.FC<LinkProps> = ({
   // target,
   // rel,
   isExternal = false, // デフォルトは内部リンク
+  'data-testid': dataTestId, // propsからdata-testidを取得するのだ
 }) => {
   // しずかなインターネットのスタイルに合わせる
   const baseStyle =
@@ -30,6 +32,7 @@ export const Link: React.FC<LinkProps> = ({
         className={`${baseStyle} ${className || ''}`}
         target="_blank" // 外部リンクは基本的に新しいタブで開く
         rel="noopener noreferrer" // セキュリティ対策
+        data-testid={dataTestId} // ここで渡すのだ
       >
         {children}
       </a>
@@ -38,7 +41,9 @@ export const Link: React.FC<LinkProps> = ({
 
   // 内部リンクの場合: NextLinkに直接スタイルを適用し、子要素のaタグは削除
   return (
-    <NextLink href={href} className={`${baseStyle} ${className || ''}`}>
+    <NextLink href={href} className={`${baseStyle} ${className || ''}`} data-testid={dataTestId}>
+      {' '}
+      // ここでも渡すのだ
       {children}
     </NextLink>
   );

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -12,11 +12,15 @@ export const Header: React.FC<HeaderProps> = ({ siteTitle = 'My Blog' }) => {
       <div className="container mx-auto px-4">
         <div className="flex flex-col md:flex-row md:items-center md:justify-between">
           <Heading level={1} className="text-xl font-semibold mb-4 md:mb-0">
-            <Link href="/" className="text-neutral-800 hover:text-neutral-600 no-underline hover:no-underline">
+            <Link
+              href="/"
+              className="text-neutral-800 hover:text-neutral-600 no-underline hover:no-underline"
+              data-testid="header-site-title"
+            >
               {siteTitle}
             </Link>
           </Heading>
-          
+
           <nav>
             <ul className="flex space-x-6">
               <li>

--- a/src/pages/author/[authorId].tsx
+++ b/src/pages/author/[authorId].tsx
@@ -1,10 +1,10 @@
 import { GetStaticProps, GetStaticPaths } from 'next';
-import { ParsedUrlQuery } from 'querystring'
+import { ParsedUrlQuery } from 'querystring';
 import React from 'react';
-import BaseLayout from '@/components/layout/BaseLayout'
-import UserProfileHeader from '@/components/features/UserProfile/UserProfileHeader'
-import TabNavigation from '@/components/features/Navigation/TabNavigation'
-import ArticleList from '@/components/features/Article/ArticleList'
+import Layout from '@/components/layout/Layout';
+import UserProfileHeader from '@/components/features/UserProfile/UserProfileHeader';
+import TabNavigation from '@/components/features/Navigation/TabNavigation';
+import ArticleList from '@/components/features/Article/ArticleList';
 import { getAllAuthorIds, getAuthorNameFromId, getPostsByAuthor, PostData } from '@/lib/posts';
 
 interface AuthorParams extends ParsedUrlQuery {
@@ -25,22 +25,22 @@ export default function AuthorPage({ authorName, posts, authorId }: AuthorPagePr
   ];
 
   return (
-    <BaseLayout>
+    <Layout>
       <div className="container mx-auto px-4 py-8">
         <UserProfileHeader userName={authorName} description={`${authorName}の記事一覧`} />
-        
+
         <TabNavigation tabs={tabs} activeHref={`/author/${authorId}`} />
-        
+
         <ArticleList articles={posts} />
       </div>
-    </BaseLayout>
+    </Layout>
   );
 }
 
 // 動的ルーティングのためのパスを生成
 export const getStaticPaths: GetStaticPaths<AuthorParams> = async () => {
   const authorIdsResult = getAllAuthorIds();
-  
+
   if (authorIdsResult.isErr()) {
     console.error('Error fetching author IDs:', authorIdsResult.error);
     return {
@@ -48,7 +48,7 @@ export const getStaticPaths: GetStaticPaths<AuthorParams> = async () => {
       fallback: false,
     };
   }
-  
+
   return {
     paths: authorIdsResult.value,
     fallback: false, // 存在しないパスは404に
@@ -66,16 +66,16 @@ export const getStaticProps: GetStaticProps<AuthorPageProps, AuthorParams> = asy
   const { authorId } = params;
   const authorName = getAuthorNameFromId(authorId);
   const postsResult = getPostsByAuthor(authorId);
-  
+
   if (postsResult.isErr()) {
     console.error(`Error fetching posts for author ${authorId}:`, postsResult.error);
     return {
       notFound: true,
     };
   }
-  
+
   const posts = postsResult.value;
-  
+
   return {
     props: {
       authorName,
@@ -83,4 +83,4 @@ export const getStaticProps: GetStaticProps<AuthorPageProps, AuthorParams> = asy
       authorId,
     },
   };
-}; 
+};

--- a/src/pages/authors.tsx
+++ b/src/pages/authors.tsx
@@ -1,7 +1,7 @@
-import { GetStaticProps } from 'next';
+import type { GetStaticProps } from 'next';
 import React from 'react';
 import Link from '@/components/common/Link';
-import BaseLayout from '@/components/layout/BaseLayout';
+import Layout from '@/components/layout/Layout';
 import Heading from '@/components/common/Heading';
 import { getAllAuthorIds, getSortedPostsData, PostData } from '@/lib/posts';
 
@@ -17,7 +17,7 @@ type AuthorsPageProps = {
 
 export default function AuthorsPage({ authors }: AuthorsPageProps) {
   return (
-    <BaseLayout>
+    <Layout>
       <div className="container mx-auto px-4 py-8">
         <Heading level={1} className="mb-8">
           著者一覧
@@ -39,7 +39,7 @@ export default function AuthorsPage({ authors }: AuthorsPageProps) {
 
         {authors.length === 0 && <p className="text-center p-6">著者が見つかりません。</p>}
       </div>
-    </BaseLayout>
+    </Layout>
   );
 }
 

--- a/src/pages/posts/[id].tsx
+++ b/src/pages/posts/[id].tsx
@@ -1,9 +1,10 @@
 import type { GetStaticProps, GetStaticPaths, GetStaticPropsContext } from 'next';
-import BaseLayout from '@/components/layout/BaseLayout';
+import { ParsedUrlQuery } from 'querystring';
+import Layout from '@/components/layout/Layout';
 import { getAllPostIds, getPostData } from '@/lib/posts';
 import type { PostData, PostsError } from '@/lib/posts';
 import ArticleHeader from '@/components/features/Article/ArticleHeader';
-import ArticleBody from '@/components/features/Article/ArticleBody';
+import { ArticleBody } from '@/components/features/Article/ArticleBody';
 import AuthorProfile from '@/components/features/Article/AuthorProfile';
 
 type Props = {
@@ -14,7 +15,7 @@ export default function Post({ post }: Props) {
   const authorId = post.author ? encodeURIComponent(post.author.toLowerCase().replace(/\s+/g, '-')) : null;
 
   return (
-    <BaseLayout>
+    <Layout>
       <div className="container mx-auto px-4 py-12 max-w-3xl">
         <article>
           <ArticleHeader
@@ -31,7 +32,7 @@ export default function Post({ post }: Props) {
           )}
         </article>
       </div>
-    </BaseLayout>
+    </Layout>
   );
 }
 

--- a/src/pages/tags.tsx
+++ b/src/pages/tags.tsx
@@ -1,7 +1,7 @@
-import { GetStaticProps } from 'next';
+import type { GetStaticProps } from 'next';
 import React from 'react';
 import Link from '@/components/common/Link';
-import BaseLayout from '@/components/layout/BaseLayout';
+import Layout from '@/components/layout/Layout';
 import Heading from '@/components/common/Heading';
 import { getAllTagsWithCount } from '@/lib/posts';
 
@@ -16,7 +16,7 @@ type TagsPageProps = {
 
 export default function TagsPage({ tags }: TagsPageProps) {
   return (
-    <BaseLayout>
+    <Layout>
       <div className="container mx-auto px-4 py-8">
         <Heading level={1} className="mb-8">
           タグ一覧
@@ -37,7 +37,7 @@ export default function TagsPage({ tags }: TagsPageProps) {
 
         {tags.length === 0 && <p className="text-center p-6">タグが見つかりません。</p>}
       </div>
-    </BaseLayout>
+    </Layout>
   );
 }
 

--- a/src/pages/tags/[tag].tsx
+++ b/src/pages/tags/[tag].tsx
@@ -1,7 +1,7 @@
 import { GetStaticProps, GetStaticPaths } from 'next';
 import { ParsedUrlQuery } from 'querystring';
 import React from 'react';
-import BaseLayout from '@/components/layout/BaseLayout';
+import Layout from '@/components/layout/Layout';
 import ArticleList from '@/components/features/Article/ArticleList';
 import Heading from '@/components/common/Heading';
 import { getAllTagIds, getPostsByTag, PostData } from '@/lib/posts';
@@ -19,7 +19,7 @@ export default function TagPage({ tag, posts }: TagPageProps) {
   const decodedTag = decodeURIComponent(tag);
 
   return (
-    <BaseLayout>
+    <Layout>
       <div className="container mx-auto px-4 py-8">
         <Heading level={1} className="mb-8">
           タグ: {decodedTag}
@@ -27,7 +27,7 @@ export default function TagPage({ tag, posts }: TagPageProps) {
 
         <ArticleList articles={posts} />
       </div>
-    </BaseLayout>
+    </Layout>
   );
 }
 

--- a/src/stories/Layout.stories.tsx
+++ b/src/stories/Layout.stories.tsx
@@ -41,7 +41,7 @@ export const Default: Story = {
     expect(childContent).toBeInTheDocument();
 
     // フッターのコピーライトが表示されているか (年を含む部分一致)
-    const footerText = await canvas.findByText(/© \d{4} My Blog. Built with Next.js and TypeScript./);
+    const footerText = await canvas.findByText(/© \d{4} My Blog. All rights reserved./);
     expect(footerText).toBeInTheDocument();
   },
 };

--- a/src/stories/Layout.stories.tsx
+++ b/src/stories/Layout.stories.tsx
@@ -32,8 +32,9 @@ export const Default: Story = {
     const canvas = within(canvasElement);
 
     // ヘッダーのブログタイトルが表示されているか
-    const headerTitle = await canvas.findByText('My Blog');
+    const headerTitle = await canvas.findByTestId('header-site-title');
     expect(headerTitle).toBeInTheDocument();
+    expect(headerTitle).toHaveTextContent('My Blog');
 
     // 子要素が表示されているか
     const childContent = await canvas.findByText('Test Content');


### PR DESCRIPTION
## 概要
Issue #59 の対応として、Layoutコンポーネントのモック方法を修正し、BaseLayoutからLayoutへの変更に伴う各ページコンポーネントのテストが正しく動作するように更新しました。

## 変更点
- `src/__tests__/pages` 以下の各テストファイルで、`@/components/layout/Layout` のモックを修正しました。
- `src/pages` 以下の各ページコンポーネントで、`BaseLayout` を `Layout` に置き換えました。
- `src/__tests__/pages/post.test.tsx` で `ArticleBody` のモックが named export に対応するように修正しました。

Closes #59 