### PR TITLE
feat: 記事一覧に「もっと見る」ボタンを設置

### DIFF
--- a/src/components/common/Link.tsx
+++ b/src/components/common/Link.tsx
@@ -42,8 +42,6 @@ export const Link: React.FC<LinkProps> = ({
   // 内部リンクの場合: NextLinkに直接スタイルを適用し、子要素のaタグは削除
   return (
     <NextLink href={href} className={`${baseStyle} ${className || ''}`} data-testid={dataTestId}>
-      {' '}
-      // ここでも渡すのだ
       {children}
     </NextLink>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,23 +1,42 @@
 import type { GetStaticProps } from 'next';
+import React, { useState, useEffect } from 'react';
 import Layout from '@/components/layout/Layout';
 import Heading from '@/components/common/Heading';
 import Paragraph from '@/components/common/Paragraph';
 import Link from '@/components/common/Link';
 import { getSortedPostsData } from '@/lib/posts';
 import type { PostData } from '@/lib/posts';
-import ArticleList from '@/components/features/Article/ArticleList';
+import Button from '@/components/common/Button';
 
 type Props = {
   posts: Omit<PostData, 'contentHtml'>[];
 };
 
-export default function Home({ posts }: Props) {
+const INITIAL_POST_COUNT = 5;
+const LOAD_MORE_COUNT = 5;
+
+export default function Home({ posts: allPosts }: Props) {
+  const [displayedPosts, setDisplayedPosts] = useState<Omit<PostData, 'contentHtml'>[]>([]);
+  const [canLoadMore, setCanLoadMore] = useState(false);
+
+  useEffect(() => {
+    setDisplayedPosts(allPosts.slice(0, INITIAL_POST_COUNT));
+    setCanLoadMore(allPosts.length > INITIAL_POST_COUNT);
+  }, [allPosts]);
+
+  const handleLoadMore = () => {
+    const currentLength = displayedPosts.length;
+    const morePosts = allPosts.slice(currentLength, currentLength + LOAD_MORE_COUNT);
+    setDisplayedPosts([...displayedPosts, ...morePosts]);
+    setCanLoadMore(allPosts.length > currentLength + LOAD_MORE_COUNT);
+  };
+
   return (
     <Layout siteTitle="My Blog">
       <div className="space-y-8">
         <Heading level={1}>Blog Posts</Heading>
         <div className="grid gap-8">
-          {posts.map((post) => (
+          {displayedPosts.map((post) => (
             <article key={post.id}>
               <Heading level={2} className="text-xl mb-1 border-none pb-0">
                 <Link href={`/posts/${post.id}`}>{post.title}</Link>
@@ -29,6 +48,13 @@ export default function Home({ posts }: Props) {
             </article>
           ))}
         </div>
+        {canLoadMore && (
+          <div className="text-center mt-8">
+            <Button onClick={handleLoadMore} variant="primary" className="px-6 py-3">
+              もっと見る
+            </Button>
+          </div>
+        )}
       </div>
     </Layout>
   );


### PR DESCRIPTION
## 概要
Issue #56 の対応として、ブログのTOPページに「もっと見る」ボタンを設置し、過去記事を段階的に読み込めるようにしました。

## 変更点
- `src/pages/index.tsx` を修正。
- 初期表示で5件の記事を表示。
- 「もっと見る」ボタンクリックで追加で5件ずつ記事を読み込み。
- すべての記事が表示されたらボタンは非表示。
- 既存の `Button` コンポーネント (`variant="primary"`) を使用し、パディングを調整。

Closes #56