### PR TITLE
feat: 「もっと見る」ボタン設置と共通ボタンのスタイル調整

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -20,7 +20,7 @@ export const Button: React.FC<ButtonProps> = ({
   let baseStyle = '';
   // 共通スタイルを更新: padding, font-size, focus は削除 (variant で指定するため)
   const commonStyle =
-    'inline-flex items-center justify-center border font-medium rounded-full transition duration-300 ease-in-out tracking-wider'; // rounded-full, tracking-wider, duration-300 を追加
+    'inline-flex items-center justify-center font-medium rounded-full transition duration-300 ease-in-out border-custom-button'; // border を border-custom-button に変更
   const disabledStyle = 'disabled:opacity-50 disabled:cursor-not-allowed';
 
   // variantに応じてスタイルを決定
@@ -28,10 +28,10 @@ export const Button: React.FC<ButtonProps> = ({
     case 'primary':
       // 背景色付きボタン (例: フッターのログインボタン)
       baseStyle =
-        'inline-flex items-center justify-center px-4 py-2 border text-base font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-neutral-500 transition duration-150 ease-in-out border-transparent text-white bg-neutral-800 hover:bg-neutral-700'; // 元のスタイルを保持
+        'inline-flex items-center justify-center px-4 py-2 text-base font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-neutral-500 transition duration-150 ease-in-out border-transparent text-white bg-neutral-800 hover:bg-neutral-700'; // border-transparent なので border-custom-button は不要
       break;
     default: // 'outline' のスタイルをしずかなインターネット風に更新
-      baseStyle = `${commonStyle} px-6 py-3.5 text-base text-main-body bg-main-bg border-main-300 hover:bg-main-100 hover:border-main-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400`; // px, py, text, bg, border, hover, focus を更新
+      baseStyle = `${commonStyle} px-6 py-3.5 text-base leading-custom-button tracking-custom-button text-main-body bg-main-bg border-main-300 hover:bg-main-100 hover:border-main-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400`; // border-custom-button は commonStyle から継承し、色は border-main-300 で指定
       break;
   }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -30,6 +30,15 @@ module.exports = {
           bg: '#fff',
         },
       },
+      lineHeight: {
+        'custom-button': '1.1',
+      },
+      letterSpacing: {
+        'custom-button': '0.32px',
+      },
+      borderWidth: {
+        'custom-button': '0.8px',
+      },
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
         'gradient-conic': 'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',


### PR DESCRIPTION
## 概要
- Issue #XX (「もっと見る」ボタンの実装)
- Issue #56 (ボタンコンポーネントのスタイル調整)

## 変更内容
- `src/pages/index.tsx`: 記事一覧に「もっと見る」ボタンの機能を追加しました。
- `src/components/common/Button.tsx`: ボタンコンポーネントの `outline` バリアントの `line-height`, `letter-spacing`, `border-width` を調整し、より「しずかなインターネット」のスタイルに近づけました。
- `tailwind.config.js`: ボタン調整用のカスタムユーティリティクラス (`leading-custom-button`, `tracking-custom-button`, `border-custom-button`) を追加しました。

## 備考
- このプルリクエストには、本来 Issue #56 で対応すべきボタンコンポーネントのスタイル調整が含まれています。

## テスト手順
1. `npm run dev` を実行します。
2. TOPページ (`/`) にアクセスし、記事が初期表示数（現在3件）よりも多い場合に「もっと見る」ボタンが表示されることを確認します。
3. 「もっと見る」ボタンをクリックすると、追加の記事が3件ずつ表示されることを確認します。
4. すべての記事が表示されると、「もっと見る」ボタンが非表示になることを確認します。
5. 各ボタン（特に `outline` バリアント）の見た目（高さ、文字間隔、線の太さなど）が調整されていることを確認します。

## 関連Issue
- resolves #XX (「もっと見る」ボタンのIssue番号を記載してください)
- resolves #56 