### PR TITLE
feat(pagination): 各種一覧ページにページネーション機能を実装

### DIFF
--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+
+type PaginationProps = {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+};
+
+export const Pagination: React.FC<PaginationProps> = ({ currentPage, totalPages, onPageChange }) => {
+  const handlePrevious = () => {
+    if (currentPage > 1) {
+      onPageChange(currentPage - 1);
+    }
+  };
+
+  const handleNext = () => {
+    if (currentPage < totalPages) {
+      onPageChange(currentPage + 1);
+    }
+  };
+
+  if (totalPages <= 1) {
+    return null; // 1ページ以下の場合は何も表示しない
+  }
+
+  // TODO: よりリッチなページ番号リストの実装 (例: 1 ... 5 6 7 ... 10)
+  const pageNumbers: number[] = [];
+  for (let i = 1; i <= totalPages; i++) {
+    pageNumbers.push(i);
+  }
+
+  return (
+    <nav aria-label="Pagination" className="flex items-center justify-between my-8">
+      <button
+        type="button"
+        onClick={handlePrevious}
+        disabled={currentPage === 1}
+        className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        前へ
+      </button>
+      <div className="flex items-center space-x-2">
+        {pageNumbers.map((number) => (
+          <button
+            key={number}
+            type="button"
+            onClick={() => onPageChange(number)}
+            className={`px-4 py-2 text-sm font-medium border rounded-md ${
+              currentPage === number
+                ? 'bg-blue-500 text-white border-blue-500'
+                : 'text-gray-700 bg-white border-gray-300 hover:bg-gray-50'
+            }`}
+          >
+            {number}
+          </button>
+        ))}
+      </div>
+      <button
+        type="button"
+        onClick={handleNext}
+        disabled={currentPage === totalPages}
+        className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        次へ
+      </button>
+    </nav>
+  );
+};
+
+export default Pagination;

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -291,3 +291,49 @@ export function getPostsByTag(tag: string): Result<Omit<PostData, 'contentHtml'>
 
   return ok(taggedPosts);
 }
+
+export function getPaginatedPostsByTagData(
+  tag: string,
+  pageNumber: number,
+  postsPerPage: number
+): Result<
+  {
+    posts: Omit<PostData, 'contentHtml'>[];
+    totalPages: number;
+    totalPosts: number;
+    currentPage: number;
+  },
+  PostsError
+> {
+  const allTaggedPostsResult = getPostsByTag(tag);
+
+  if (allTaggedPostsResult.isErr()) {
+    return err(allTaggedPostsResult.error);
+  }
+
+  const allTaggedPosts = allTaggedPostsResult.value;
+  const totalPosts = allTaggedPosts.length;
+  const totalPages = Math.ceil(totalPosts / postsPerPage);
+
+  // ページ番号が不正な場合の調整
+  let currentPage = pageNumber;
+  if (currentPage < 1) {
+    currentPage = 1;
+  }
+  if (currentPage > totalPages && totalPages > 0) {
+    currentPage = totalPages;
+  }
+  // 記事がない場合 (totalPosts === 0)、currentPage は 1 (または 0) になる
+  // totalPages が 0 の場合、currentPage も 0 or 1 を維持する
+
+  const startIndex = (currentPage - 1) * postsPerPage;
+  const endIndex = startIndex + postsPerPage;
+  const paginatedPosts = allTaggedPosts.slice(startIndex, endIndex);
+
+  return ok({
+    posts: paginatedPosts,
+    totalPages,
+    totalPosts,
+    currentPage,
+  });
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,42 +1,48 @@
 import type { GetStaticProps } from 'next';
-import React, { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
 import Layout from '@/components/layout/Layout';
 import Heading from '@/components/common/Heading';
 import Paragraph from '@/components/common/Paragraph';
 import Link from '@/components/common/Link';
-import { getSortedPostsData } from '@/lib/posts';
+import { getPaginatedPostsData } from '@/lib/posts';
 import type { PostData } from '@/lib/posts';
-import Button from '@/components/common/Button';
+import { Pagination } from '@/components/common/Pagination';
 
 type Props = {
   posts: Omit<PostData, 'contentHtml'>[];
+  currentPage: number;
+  totalPages: number;
+  totalPosts: number;
 };
 
-const INITIAL_POST_COUNT = 5;
-const LOAD_MORE_COUNT = 5;
+const POSTS_PER_PAGE = 5;
 
-export default function Home({ posts: allPosts }: Props) {
-  const [displayedPosts, setDisplayedPosts] = useState<Omit<PostData, 'contentHtml'>[]>([]);
-  const [canLoadMore, setCanLoadMore] = useState(false);
+export default function Home({ posts, currentPage, totalPages, totalPosts }: Props) {
+  const router = useRouter();
 
-  useEffect(() => {
-    setDisplayedPosts(allPosts.slice(0, INITIAL_POST_COUNT));
-    setCanLoadMore(allPosts.length > INITIAL_POST_COUNT);
-  }, [allPosts]);
-
-  const handleLoadMore = () => {
-    const currentLength = displayedPosts.length;
-    const morePosts = allPosts.slice(currentLength, currentLength + LOAD_MORE_COUNT);
-    setDisplayedPosts([...displayedPosts, ...morePosts]);
-    setCanLoadMore(allPosts.length > currentLength + LOAD_MORE_COUNT);
+  const handlePageChange = (page: number) => {
+    if (page === 1) {
+      router.push('/');
+    } else {
+      router.push(`/page/${page}`);
+    }
   };
+
+  if (totalPosts === 0) {
+    return (
+      <Layout siteTitle="My Blog">
+        <Heading level={1}>Blog Posts</Heading>
+        <Paragraph>まだ投稿がありません。</Paragraph>
+      </Layout>
+    );
+  }
 
   return (
     <Layout siteTitle="My Blog">
       <div className="space-y-8">
         <Heading level={1}>Blog Posts</Heading>
         <div className="grid gap-8">
-          {displayedPosts.map((post) => (
+          {posts.map((post) => (
             <article key={post.id}>
               <Heading level={2} className="text-xl mb-1 border-none pb-0">
                 <Link href={`/posts/${post.id}`}>{post.title}</Link>
@@ -48,12 +54,8 @@ export default function Home({ posts: allPosts }: Props) {
             </article>
           ))}
         </div>
-        {canLoadMore && (
-          <div className="text-center mt-8">
-            <Button onClick={handleLoadMore} variant="primary" className="px-6 py-3">
-              もっと見る
-            </Button>
-          </div>
+        {totalPages > 1 && (
+          <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={handlePageChange} />
         )}
       </div>
     </Layout>
@@ -61,17 +63,21 @@ export default function Home({ posts: allPosts }: Props) {
 }
 
 export const getStaticProps: GetStaticProps<Props> = async () => {
-  const postsResult = getSortedPostsData();
+  const postsResult = getPaginatedPostsData(1, POSTS_PER_PAGE);
 
   if (postsResult.isOk()) {
+    const { posts, totalPages, totalPosts } = postsResult.value;
     return {
       props: {
-        posts: postsResult.value,
+        posts,
+        currentPage: 1,
+        totalPages,
+        totalPosts,
       },
     };
   }
 
-  console.error('Error fetching posts:', postsResult.error);
+  console.error('Error fetching posts for page 1:', postsResult.error);
   return {
     notFound: true,
   };

--- a/src/pages/page/[page].tsx
+++ b/src/pages/page/[page].tsx
@@ -1,0 +1,132 @@
+import type { GetStaticProps, GetStaticPaths } from 'next'; // GetStaticPaths をインポート
+import { useRouter } from 'next/router';
+import Layout from '@/components/layout/Layout';
+import Heading from '@/components/common/Heading';
+import Paragraph from '@/components/common/Paragraph';
+import Link from '@/components/common/Link';
+import { getPaginatedPostsData, getSortedPostsData } from '@/lib/posts'; // getSortedPostsData も一時的に利用（getStaticPathsのため）
+import type { PostData } from '@/lib/posts';
+import { Pagination } from '@/components/common/Pagination';
+
+type Props = {
+  posts: Omit<PostData, 'contentHtml'>[];
+  currentPage: number;
+  totalPages: number;
+  totalPosts: number;
+};
+
+const POSTS_PER_PAGE = 5;
+
+export default function PageNumberPage({ posts, currentPage, totalPages, totalPosts }: Props) {
+  const router = useRouter();
+
+  const handlePageChange = (page: number) => {
+    if (page === 1) {
+      router.push('/');
+    } else {
+      router.push(`/page/${page}`);
+    }
+  };
+
+  if (!posts || posts.length === 0) {
+    // currentPage が不正な場合（大きすぎる場合など）postsが空になることがある
+    return (
+      <Layout siteTitle="My Blog">
+        <Heading level={1}>Blog Posts</Heading>
+        <Paragraph>指定されたページの記事は見つかりませんでした。</Paragraph>
+        <Paragraph>
+          <Link href="/">最初のページへ</Link>
+        </Paragraph>
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout siteTitle={`My Blog - Page ${currentPage}`}>
+      <div className="space-y-8">
+        <Heading level={1}>
+          Blog Posts <span className="text-base font-normal text-neutral-500">(Page {currentPage})</span>
+        </Heading>
+        <div className="grid gap-8">
+          {posts.map((post) => (
+            <article key={post.id}>
+              <Heading level={2} className="text-xl mb-1 border-none pb-0">
+                <Link href={`/posts/${post.id}`}>{post.title}</Link>
+              </Heading>
+              <Paragraph className="text-sm text-neutral-500 mb-0">
+                {post.date}
+                {post.tags && post.tags.length > 0 && <span className="ml-4">Tags: {post.tags.join(', ')}</span>}
+              </Paragraph>
+            </article>
+          ))}
+        </div>
+        {totalPages > 1 && (
+          <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={handlePageChange} />
+        )}
+      </div>
+    </Layout>
+  );
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  // 全記事を取得して総ページ数を計算
+  const postsResult = getSortedPostsData(); // ここではページ分割されていない全記事リストを取得
+  if (postsResult.isErr()) {
+    console.error('Error fetching posts for paths:', postsResult.error);
+    return { paths: [], fallback: 'blocking' }; // エラー時は fallback を blocking にして ISR を試みるか、false で 404
+  }
+  const totalPosts = postsResult.value.length;
+  const totalPages = Math.ceil(totalPosts / POSTS_PER_PAGE);
+
+  const paths = Array.from({ length: totalPages - 1 }, (_, i) => ({
+    params: { page: (i + 2).toString() }, // 2ページ目からtotalPagesまで
+  }));
+
+  return {
+    paths,
+    fallback: false, // 存在しないページは404
+  };
+};
+
+export const getStaticProps: GetStaticProps<Props, { page: string }> = async (context) => {
+  const pageString = context.params?.page ?? '1';
+  const page = parseInt(pageString, 10);
+
+  if (Number.isNaN(page) || page <= 1) {
+    // 1ページ目や不正なページは / にリダイレクトまたは404を返す想定だが、ここではビルド時にエラーとする
+    // このパス (/page/[page]) は2ページ目以降を想定しているため、pageが1以下の場合はnotFoundを返す。
+    // 本来は index.tsx が1ページ目を処理する。
+    return { notFound: true };
+  }
+
+  const postsResult = getPaginatedPostsData(page, POSTS_PER_PAGE);
+
+  if (postsResult.isOk()) {
+    const { posts, totalPages, totalPosts } = postsResult.value;
+
+    if (page > totalPages && totalPages > 0) {
+      // 要求されたページが実際の総ページ数を超えている場合 (記事が削除されたなどで総ページ数が減った場合など)
+      return { notFound: true };
+    }
+    if (posts.length === 0 && totalPosts > 0 && page > 1) {
+      // 要求されたページに記事が存在しないが、ブログ全体には記事が存在し、かつ1ページ目ではない場合
+      // (例: 5件/ページで総記事6件の時、page=3をリクエストされた場合など)
+      // getPaginatedPostsData内でcurrentPageがtotalPagesに調整されるので、ここに来るのは稀かもしれないが念のため
+      return { notFound: true };
+    }
+
+    return {
+      props: {
+        posts,
+        currentPage: page,
+        totalPages,
+        totalPosts,
+      },
+    };
+  }
+
+  console.error(`Error fetching posts for page ${page}:`, postsResult.error);
+  return {
+    notFound: true,
+  };
+};

--- a/src/pages/tags/[tag]/page/[pageNumber].tsx
+++ b/src/pages/tags/[tag]/page/[pageNumber].tsx
@@ -1,0 +1,152 @@
+import type { GetStaticProps, GetStaticPaths } from 'next';
+import { ParsedUrlQuery } from 'querystring';
+import { useRouter } from 'next/router';
+import React from 'react';
+import Layout from '@/components/layout/Layout';
+import ArticleList from '@/components/features/Article/ArticleList';
+import Heading from '@/components/common/Heading';
+import Paragraph from '@/components/common/Paragraph';
+import Link from '@/components/common/Link';
+import {
+  getAllTagIds,
+  getPaginatedPostsByTagData,
+  getPostsByTag, // getStaticPathsで総ページ数計算のために一時的に使用
+  PostData,
+} from '@/lib/posts';
+import { Pagination } from '@/components/common/Pagination';
+
+interface TagPageParams extends ParsedUrlQuery {
+  tag: string;
+  pageNumber: string;
+}
+
+type TagPaginatedPageProps = {
+  tag: string; // URLエンコードされたタグ名
+  posts: Omit<PostData, 'contentHtml'>[];
+  currentPage: number;
+  totalPages: number;
+  totalPosts: number;
+};
+
+const POSTS_PER_PAGE = 5;
+
+export default function TagPaginatedPage({ tag, posts, currentPage, totalPages, totalPosts }: TagPaginatedPageProps) {
+  const router = useRouter();
+  const decodedTag = decodeURIComponent(tag);
+
+  const handlePageChange = (page: number) => {
+    if (page === 1) {
+      router.push(`/tags/${tag}`);
+    } else {
+      router.push(`/tags/${tag}/page/${page}`);
+    }
+  };
+
+  if (!posts || posts.length === 0) {
+    return (
+      <Layout siteTitle={`タグ: ${decodedTag} - My Blog`}>
+        <div className="container mx-auto px-4 py-8">
+          <Heading level={1} className="mb-4">
+            タグ: {decodedTag} (Page {currentPage})
+          </Heading>
+          <Paragraph>指定されたページの記事は見つかりませんでした。</Paragraph>
+          <Paragraph className="mt-4">
+            <Link href={`/tags/${tag}`}>このタグの最初のページへ</Link>
+          </Paragraph>
+        </div>
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout siteTitle={`タグ: ${decodedTag} (${currentPage}/${totalPages}) - My Blog`}>
+      <div className="container mx-auto px-4 py-8">
+        <Heading level={1} className="mb-8">
+          タグ: {decodedTag}
+          {totalPages > 1 && (
+            <span className="text-base font-normal text-neutral-500 ml-2">
+              (Page {currentPage}/{totalPages})
+            </span>
+          )}
+        </Heading>
+
+        <ArticleList articles={posts} />
+
+        {totalPages > 1 && (
+          <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={handlePageChange} />
+        )}
+      </div>
+    </Layout>
+  );
+}
+
+export const getStaticPaths: GetStaticPaths<TagPageParams> = async () => {
+  const tagIdsResult = getAllTagIds();
+  if (tagIdsResult.isErr()) {
+    console.error('Error fetching tag IDs for paginated paths:', tagIdsResult.error);
+    return { paths: [], fallback: 'blocking' };
+  }
+
+  const paths: Array<{ params: TagPageParams }> = [];
+
+  for (const tagIdObj of tagIdsResult.value) {
+    const tag = tagIdObj.params.tag; // URLエンコードされたタグ
+    // このタグの総記事数を取得して総ページ数を計算
+    const postsForTagResult = getPostsByTag(tag);
+    if (postsForTagResult.isOk()) {
+      const totalPostsForTag = postsForTagResult.value.length;
+      const totalPagesForTag = Math.ceil(totalPostsForTag / POSTS_PER_PAGE);
+
+      // 2ページ目から totalPagesForTag までのパスを生成
+      for (let i = 2; i <= totalPagesForTag; i++) {
+        paths.push({ params: { tag, pageNumber: i.toString() } });
+      }
+    }
+  }
+
+  return {
+    paths,
+    fallback: false, // 存在しないページは404
+  };
+};
+
+export const getStaticProps: GetStaticProps<TagPaginatedPageProps, TagPageParams> = async ({ params }) => {
+  if (!params) {
+    return { notFound: true };
+  }
+
+  const { tag, pageNumber: pageNumberString } = params;
+  const pageNumber = parseInt(pageNumberString, 10);
+
+  if (Number.isNaN(pageNumber) || pageNumber <= 1) {
+    // このパスは2ページ目以降を想定。1ページ目や不正な値は notFound。
+    return { notFound: true };
+  }
+
+  const pageResult = getPaginatedPostsByTagData(tag, pageNumber, POSTS_PER_PAGE);
+
+  if (pageResult.isErr()) {
+    console.error(`Error fetching posts for tag ${tag}, page ${pageNumber}:`, pageResult.error);
+    return { notFound: true };
+  }
+
+  const { posts, totalPages, totalPosts, currentPage } = pageResult.value;
+
+  if (posts.length === 0 && totalPosts > 0 && pageNumber > 1) {
+    // 要求されたページに記事がないが、ブログ全体には記事があり、1ページ目ではない場合
+    return { notFound: true };
+  }
+  if (pageNumber > totalPages && totalPages > 0) {
+    return { notFound: true };
+  }
+
+  return {
+    props: {
+      tag,
+      posts,
+      currentPage,
+      totalPages,
+      totalPosts,
+    },
+  };
+};


### PR DESCRIPTION
## 概要
Issue #52 の実装として、ブログの主要な一覧ページにページネーション機能を導入しました。

## 変更内容
- 追加: `src/components/common/Pagination.tsx` - ページネーションUIコンポーネント
- 追加: `src/pages/page/[page].tsx` - トップ記事一覧の2ページ目以降
- 追加: `src/pages/tags/[tag]/page/[pageNumber].tsx` - タグ別記事一覧の2ページ目以降
- 更新: `src/lib/posts.ts` - `getPaginatedPostsData`, `getPaginatedPostsByTagData` 関数を追加
- 更新: `src/pages/index.tsx` - トップページを1ページ目としてページネーション導入
- 更新: `src/pages/tags/[tag].tsx` - タグ別記事一覧の1ページ目としてページネーション導入

## テスト手順
1. `npm run dev` を実行
2. トップページ (`/`) にアクセスし、記事が5件ずつ表示され、ページネーションが機能することを確認
3. 記事が6件以上ある場合、2ページ目 (`/page/2`) にアクセスし、続きの記事とページネーションが表示されることを確認
4. いずれかのタグ一覧ページ (`/tags/some-tag`) にアクセスし、記事が5件ずつ表示され、ページネーションが機能することを確認
5. そのタグの記事が6件以上ある場合、2ページ目 (`/tags/some-tag/page/2`) にアクセスし、続きの記事とページネーションが表示されることを確認
6. 存在しないページ番号や不正なページ番号にアクセスした場合、適切に404ページが表示されること（または最初のページ/最後のページに調整されること）を確認

Closes #52 