### PR TITLE
feat: OGP対応とビルド時OGP画像生成 (Closes #51)

### DIFF
--- a/.cursor/rules/index.mdc
+++ b/.cursor/rules/index.mdc
@@ -14,7 +14,7 @@ alwaysApply: true
 
 反面、現在のコンテキストに応じた処理は苦手です。コンテキストが不明瞭な時は、ユーザーに確認します。
 
-このプロジェクトは[https://github.com/sotaroNishioka/my-blog](https://github.com/sotaroNishioka/my-blog)で管理されています。
+このプロジェクトは[https://github.com/sotaroNishioka/my-blog](mdc:https:/github.com/sotaroNishioka/my-blog)で管理されています。
 
 
 # 作業フロー
@@ -106,6 +106,7 @@ git branch -d issue-42-auth-result-type
 
 ### 5 プルリクエスト作成のポイント
 
+- プルリクエストは必ずMCPサーバーを経由して作成する
 - タイトルには変更の種類（feat, fix など）を含める
 - 本文には必ず関連するIssue番号を記載（`Closes #42` など）
 - スクリーンショットや動作確認方法を含めるとレビューがスムーズに

--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -1,0 +1,63 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main # mainブランチへのpushでトリガー
+  workflow_dispatch: # 手動実行も可能にする
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18' # プロジェクトで使用しているNode.jsのバージョンに合わせる
+          cache: 'yarn' # npmの場合は 'npm'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile # npmの場合は npm ci
+
+      - name: Install OG Image generation tools
+        run: yarn add satori gray-matter # npmの場合は npm install satori gray-matter
+
+      - name: Generate OG Images for posts
+        run: node scripts/generate-og-images-for-posts.mjs
+        # フォントファイルが存在することを確認（オプション）
+        # run: |
+        #   if [ ! -f "public/fonts/NotoSansJP-Bold.otf" ] || [ ! -f "public/fonts/NotoSansJP-Regular.otf" ]; then
+        #     echo "Error: Font files not found in public/fonts/"
+        #     exit 1
+        #   fi
+        #   node scripts/generate-og-images-for-posts.mjs
+
+      - name: Build Next.js application
+        env:
+          # next.config.jsで basePath を設定している場合は、それも環境変数で渡す必要があるかもしれない
+          # BASE_PATH: /my-blog # 例
+          NEXT_PUBLIC_BASE_PATH: /my-blog # next.config.jsのbasePathと合わせる
+        run: yarn build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./out # Next.jsの静的エクスポート出力ディレクトリ
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4 

--- a/public/default-og-image.svg
+++ b/public/default-og-image.svg
@@ -1,0 +1,9 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="1200" height="630" fill="#F3F4F6"/>
+<text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="'Noto Sans JP', 'BIZ UDPGothic', sans-serif" font-size="100" fill="#1F2937" font-weight="bold">
+My Blog
+</text>
+<text x="50%" y="60%" dominant-baseline="middle" text-anchor="middle" font-family="'Noto Sans JP', 'BIZ UDPGothic', sans-serif" font-size="40" fill="#4B5563">
+日記やエッセイにちょうどいい
+</text>
+</svg> 

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,19 +1,56 @@
 import React from 'react';
+import Head from 'next/head';
 import Header from './Header';
 import Footer from './Footer';
+import { SITE_TITLE, SITE_DESCRIPTION, SITE_URL, DEFAULT_OG_IMAGE_URL } from '@/lib/constants';
 
 type LayoutProps = {
   children: React.ReactNode;
   siteTitle?: string;
+  pageTitle?: string;
+  description?: string;
+  ogImageUrl?: string;
+  ogUrl?: string;
+  ogType?: 'website' | 'article';
 };
 
-export const Layout: React.FC<LayoutProps> = ({ children, siteTitle }) => {
+export const Layout: React.FC<LayoutProps> = ({
+  children,
+  siteTitle = SITE_TITLE,
+  pageTitle,
+  description,
+  ogImageUrl,
+  ogUrl,
+  ogType = 'website',
+}) => {
+  const displayTitle = pageTitle ? `${pageTitle} | ${SITE_TITLE}` : SITE_TITLE;
+  const currentDescription = description || SITE_DESCRIPTION;
+  const currentOgImageUrl = ogImageUrl || DEFAULT_OG_IMAGE_URL;
+  const currentOgUrl = ogUrl || SITE_URL;
+
   return (
-    <div className="flex flex-col min-h-screen">
-      <Header siteTitle={siteTitle} />
-      <main className="flex-grow container mx-auto px-4 py-8">{children}</main>
-      <Footer />
-    </div>
+    <>
+      <Head>
+        <title>{displayTitle}</title>
+        <meta name="description" content={currentDescription} />
+        <meta property="og:site_name" content={SITE_TITLE} />
+        <meta property="og:title" content={pageTitle || SITE_TITLE} />
+        <meta property="og:description" content={currentDescription} />
+        <meta property="og:url" content={currentOgUrl} />
+        <meta property="og:type" content={ogType} />
+        <meta property="og:image" content={currentOgImageUrl} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={pageTitle || SITE_TITLE} />
+        <meta name="twitter:description" content={currentDescription} />
+        <meta name="twitter:image" content={currentOgImageUrl} />
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+      <div className="flex flex-col min-h-screen">
+        <Header siteTitle={siteTitle} />
+        <main className="flex-grow container mx-auto px-4 py-8">{children}</main>
+        <Footer />
+      </div>
+    </>
   );
 };
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,6 @@
+export const SITE_TITLE = 'My Blog';
+export const SITE_DESCRIPTION = '日記やエッセイにちょうどいい 文章書き散らしサービス';
+export const SITE_URL = 'https://sotaronishioka.github.io/my-blog'; // GitHub PagesのURL
+export const DEFAULT_OG_IMAGE_URL = `${SITE_URL}/default-og-image.svg`; // デフォルトOGP画像のURLをSVGに変更
+
+// 他にもサイト全体で使う定数があればここに追加できます

--- a/src/pages/author/[authorId].tsx
+++ b/src/pages/author/[authorId].tsx
@@ -6,6 +6,7 @@ import UserProfileHeader from '@/components/features/UserProfile/UserProfileHead
 import TabNavigation from '@/components/features/Navigation/TabNavigation';
 import ArticleList from '@/components/features/Article/ArticleList';
 import { getAllAuthorIds, getAuthorNameFromId, getPostsByAuthor, PostData } from '@/lib/posts';
+import { SITE_URL, SITE_DESCRIPTION, DEFAULT_OG_IMAGE_URL } from '@/lib/constants';
 
 interface AuthorParams extends ParsedUrlQuery {
   authorId: string;
@@ -24,8 +25,12 @@ export default function AuthorPage({ authorName, posts, authorId }: AuthorPagePr
     // 将来的に「人気の記事」や「最新の記事」など他のタブを追加できる
   ];
 
+  const pageTitle = `${authorName} の記事一覧`;
+  const description = `${authorName} による記事の一覧です。`;
+  const ogUrl = `${SITE_URL}/author/${authorId}`;
+
   return (
-    <Layout>
+    <Layout pageTitle={pageTitle} description={description} ogUrl={ogUrl}>
       <div className="container mx-auto px-4 py-8">
         <UserProfileHeader userName={authorName} description={`${authorName}の記事一覧`} />
 

--- a/src/pages/posts/[id].tsx
+++ b/src/pages/posts/[id].tsx
@@ -19,8 +19,8 @@ export default function Post({ post }: Props) {
   return (
     <Layout
       pageTitle={post.title}
-      description={post.excerpt}
-      ogImageUrl={post.ogImage ? `${SITE_URL}${post.ogImage.startsWith('/') ? '' : '/'}${post.ogImage}` : undefined}
+      description={post.excerpt || undefined}
+      ogImageUrl={`/og-images/posts/${post.id}.svg`}
       ogUrl={articleUrl}
       ogType="article"
     >

--- a/src/pages/posts/[id].tsx
+++ b/src/pages/posts/[id].tsx
@@ -6,6 +6,7 @@ import type { PostData, PostsError } from '@/lib/posts';
 import ArticleHeader from '@/components/features/Article/ArticleHeader';
 import { ArticleBody } from '@/components/features/Article/ArticleBody';
 import AuthorProfile from '@/components/features/Article/AuthorProfile';
+import { SITE_URL } from '@/lib/constants';
 
 type Props = {
   post: PostData;
@@ -13,9 +14,16 @@ type Props = {
 
 export default function Post({ post }: Props) {
   const authorId = post.author ? encodeURIComponent(post.author.toLowerCase().replace(/\s+/g, '-')) : null;
+  const articleUrl = `${SITE_URL}/posts/${post.id}`;
 
   return (
-    <Layout>
+    <Layout
+      pageTitle={post.title}
+      description={post.excerpt}
+      ogImageUrl={post.ogImage ? `${SITE_URL}${post.ogImage.startsWith('/') ? '' : '/'}${post.ogImage}` : undefined}
+      ogUrl={articleUrl}
+      ogType="article"
+    >
       <div className="container mx-auto px-4 py-12 max-w-3xl">
         <article>
           <ArticleHeader

--- a/src/pages/tags/[tag].tsx
+++ b/src/pages/tags/[tag].tsx
@@ -9,6 +9,7 @@ import { getAllTagIds, getPaginatedPostsByTagData, PostData } from '@/lib/posts'
 import { Pagination } from '@/components/common/Pagination';
 import Paragraph from '@/components/common/Paragraph';
 import Link from '@/components/common/Link';
+import { SITE_URL } from '@/lib/constants';
 
 interface TagParams extends ParsedUrlQuery {
   tag: string;
@@ -36,9 +37,19 @@ export default function TagPage({ tag, posts, currentPage, totalPages, totalPost
     }
   };
 
+  const pageTitle = `タグ: ${decodedTag}${
+    totalPages > 1 && currentPage > 1 ? ` (${currentPage}/${totalPages}ページ目)` : ''
+  }`;
+  const description = `「${decodedTag}」タグが付いた記事の一覧です。`;
+  const ogUrl = currentPage === 1 ? `${SITE_URL}/tags/${tag}` : `${SITE_URL}/tags/${tag}/page/${currentPage}`;
+
   if (totalPosts === 0) {
     return (
-      <Layout siteTitle={`タグ: ${decodedTag} - My Blog`}>
+      <Layout
+        pageTitle={`タグ: ${decodedTag}`}
+        description={`「${decodedTag}」タグの記事はまだありません。`}
+        ogUrl={`${SITE_URL}/tags/${tag}`}
+      >
         <div className="container mx-auto px-4 py-8">
           <Heading level={1} className="mb-4">
             タグ: {decodedTag}
@@ -53,7 +64,7 @@ export default function TagPage({ tag, posts, currentPage, totalPages, totalPost
   }
 
   return (
-    <Layout siteTitle={`タグ: ${decodedTag}${totalPages > 1 ? ` (${currentPage}/${totalPages})` : ''} - My Blog`}>
+    <Layout pageTitle={pageTitle} description={description} ogUrl={ogUrl}>
       <div className="container mx-auto px-4 py-8">
         <Heading level={1} className="mb-8">
           タグ: {decodedTag}


### PR DESCRIPTION
## 概要
SNSなどでシェアされたときに適切なタイトル、説明、画像が表示されるように、各ページにOGPメタデータを設定します。
また、各記事ページ用に、記事タイトルと抜粋を含むOGP画像をビルド時に動的に生成するようにしました。

Issue #51

## 主な変更内容
- **共通OGP設定:**
    - `Layout`コンポーネントにOGP関連propsを追加し、共通およびページ固有のOGPタグを生成。
    - サイト共通情報は `src/lib/constants.ts` に分離。
- **記事データ拡張:**
    - `PostData`型に `excerpt` と `ogImage` (frontmatter用) を追加。
    - `getStaticProps`で `undefined` を返すとエラーになるため、オプショナルな値は `null` を返すように修正。
- **ページごとのOGP設定:**
    - トップ、記事詳細、著者、タグの各ページで `Layout` にOGP情報を連携。
- **デフォルトOGP画像のSVG化:**
    - サイト共通のデフォルトOGP画像をSVG (`public/default-og-image.svg`) で作成。
- **記事ごとのOGP画像自動生成:**
    - `satori` を使用し、記事タイトルと抜粋からOGP画像を生成するスクリプト (`scripts/generate-og-images-for-posts.mjs`) を追加。
    - 生成された画像は `public/og-images/posts/[記事ID].svg` に保存。
    - 記事詳細ページでは、この生成された画像を参照するように `ogImageUrl` を設定。
- **GitHub Actions ワークフロー:**
    - OGP画像生成スクリプトの実行、Next.jsビルド、GitHub Pagesへのデプロイを行うワークフロー (`.github/workflows/gh-pages-deploy.yml`) を新規作成。

## ご確認いただきたいこと
- **フォントファイルの配置:** リポジトリの `public/fonts/` に `NotoSansJP-Bold.otf` と `NotoSansJP-Regular.otf` を配置してください (GitHub ActionsでOGP画像生成時に必要です)。
- **`next.config.js`:** `basePath` や `output: 'export'` の設定がプロジェクトの状況と合っているかご確認ください。
- **パッケージマネージャーとNode.jsバージョン:** ワークフローファイル内の `yarn`/`npm` コマンドやNode.jsバージョンがプロジェクトと一致しているかご確認ください。
- **デプロイ後の確認:**
    - 各種ページのOGPが意図通り表示されるか (OGP確認ツールなど)。
    - 記事ページのOGP画像が、その記事の内容で生成されたものになっているか。

Closes #51